### PR TITLE
bump libp2p to 3.5.3 to fix dial bug (missing public key)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmXnaDLonE9YBTVDdWBM6Jb5YxxmW1MHMkXzgsnu1jTEmK",
+      "hash": "QmR61Ut9oN9mEacVUDWpvvhRPYXSxHEAZVbZkiLy9tKmdr",
       "name": "go-libp2p",
-      "version": "3.4.3"
+      "version": "3.5.3"
     }
   ],
   "gxVersion": "0.9.0",


### PR DESCRIPTION
So it turns out that dialing from go to javascript was failing because libp2p wasn't sending the public key from go.  That got fixed [a few days ago](https://github.com/libp2p/go-libp2p/commit/65273ab3e7fd033887f5276fdb51df4028d8ebe8), so this bumps libp2p to the latest published version.

Now I can ping javascript nodes from go!