### PR TITLE
A couple of fixes: SQLite tuning and pings

### DIFF
--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 )
 
 func apiError(w http.ResponseWriter, status int, err error) {
@@ -41,7 +42,10 @@ func (node *Node) httpPing(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = node.doPing(r.Context(), pid)
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	err = node.doPing(ctx, pid)
 	if err != nil {
 		apiError(w, http.StatusNotFound, err)
 		return

--- a/mcnode/db.go
+++ b/mcnode/db.go
@@ -272,7 +272,14 @@ func (sdb *SQLiteDB) Open(home string) error {
 		if err != nil {
 			return err
 		}
+
+		err = sdb.tuneDB()
+		if err != nil {
+			return err
+		}
 	}
+
+	sdb.configPool()
 
 	return sdb.prepareStatements()
 }
@@ -285,4 +292,15 @@ func (sdb *SQLiteDB) openDB(dbpath string) error {
 
 	sdb.db = db
 	return nil
+}
+
+func (sdb *SQLiteDB) tuneDB() error {
+	_, err := sdb.db.Exec("PRAGMA journal_mode=WAL")
+	return err
+}
+
+func (sdb *SQLiteDB) configPool() {
+	// disable connection pooling as lock contention totally kills
+	// concurrent write performance
+	sdb.db.SetMaxOpenConns(1)
 }

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -232,6 +232,11 @@ func (node *Node) doLookup(ctx context.Context, pid p2p_peer.ID) (empty p2p_psto
 		return empty, NoDirectory
 	}
 
+	node.host.Connect(ctx, *node.dir)
+	if err != nil {
+		return empty, err
+	}
+
 	s, err := node.host.NewStream(ctx, node.dir.ID, "/mediachain/dir/lookup")
 	if err != nil {
 		return empty, err


### PR DESCRIPTION
SQLite tuning:
- tune concurrent write performance by disabling the connection pooling (lock contention!) and enabling Write-Ahead Logging

/ping protocol:
- Ensure there is a connection to the directory before trying to open a stream
- Add a 30s timeout to /ping; one day it may become a request parameter (and be common with other requests that access remote resources)