### PR TITLE
Fix Delete deadlock when connection pooling is disabled

### DIFF
--- a/mc/query/query.go
+++ b/mc/query/query.go
@@ -15,6 +15,10 @@ const (
 	OpDelete
 )
 
+func (q *Query) WithLimit(limit int) *Query {
+	return &Query{q.Op, q.namespace, q.selector, q.criteria, limit}
+}
+
 type QuerySelector interface {
 	SelectorType() string
 }

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -191,6 +191,9 @@ func (node *Node) httpDelete(w http.ResponseWriter, r *http.Request) {
 	count, err := node.db.Delete(q)
 	if err != nil {
 		apiError(w, http.StatusInternalServerError, err)
+		if count > 0 {
+			fmt.Fprintf(w, "Partial delete: %d statements deleted", count)
+		}
 		return
 	}
 

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -192,7 +192,7 @@ func (node *Node) httpDelete(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		apiError(w, http.StatusInternalServerError, err)
 		if count > 0 {
-			fmt.Fprintf(w, "Partial delete: %d statements deleted", count)
+			fmt.Fprintf(w, "Partial delete: %d statements deleted\n", count)
 		}
 		return
 	}

--- a/mcnode/db.go
+++ b/mcnode/db.go
@@ -187,7 +187,11 @@ func (sdb *SQLDB) Delete(q *mcq.Query) (int, error) {
 		count += 1
 	}
 
-	tx.Commit()
+	err = tx.Commit()
+	if err != nil {
+		return 0, err
+	}
+
 	return count, nil
 }
 

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -10,7 +10,6 @@ import (
 	mc "github.com/mediachain/concat/mc"
 	mcq "github.com/mediachain/concat/mc/query"
 	pb "github.com/mediachain/concat/proto"
-	"log"
 	"sync"
 	"time"
 )
@@ -90,8 +89,8 @@ func (node *Node) doPublish(ns string, body interface{}) (string, error) {
 	default:
 		return "", BadStatementBody
 	}
-	// only sign it with shiny ECC keys, don't bother with RSA
-	log.Printf("Publish statement %s", stmt.Id)
+
+	// TODO signatures: only sign it with shiny ECC keys, don't bother with RSA
 
 	err := node.db.Put(stmt)
 	return stmt.Id, err


### PR DESCRIPTION
So in order to not kill concurrent write performance, sqlite needs to be used with conn pooling disabled.
Unfortunately this causes Delete to deadlock, as it is using a streaming query to fetch the ids for deletion.
On the other hand simply fetching all the ids together in memory can lead to problems for large datasets (too much memory).
So in order to have our cake and eat it too (at least most of it), delete operates in batches.
The ugly side is that we can now have partial deletes, which are distinguished by both the returned count being >0, and the error being non-nil.

In other changes, the node has stopped being chatty in statement publication.