### PR TITLE
Remote Query Protocol

### DIFF
--- a/mc/message.go
+++ b/mc/message.go
@@ -1,6 +1,7 @@
 package mc
 
 import (
+	"fmt"
 	p2p_peer "github.com/ipfs/go-libp2p-peer"
 	p2p_pstore "github.com/ipfs/go-libp2p-peerstore"
 	multiaddr "github.com/jbenet/go-multiaddr"
@@ -32,4 +33,44 @@ func PBToPeerInfo(pbpi *pb.PeerInfo) (empty p2p_pstore.PeerInfo, err error) {
 	}
 
 	return p2p_pstore.PeerInfo{pid, addrs}, nil
+}
+
+type ValueError string
+
+func (v ValueError) Error() string {
+	return string(v)
+}
+
+func SimpleValue(val interface{}) (*pb.SimpleValue, error) {
+	switch val := val.(type) {
+	case int:
+		return &pb.SimpleValue{&pb.SimpleValue_IntValue{int64(val)}}, nil
+
+	case int64:
+		return &pb.SimpleValue{&pb.SimpleValue_IntValue{val}}, nil
+
+	case string:
+		return &pb.SimpleValue{&pb.SimpleValue_StringValue{val}}, nil
+
+	case *pb.Statement:
+		return &pb.SimpleValue{&pb.SimpleValue_Stmt{val}}, nil
+
+	case *pb.StatementBody:
+		return &pb.SimpleValue{&pb.SimpleValue_StmtBody{val}}, nil
+
+	default:
+		return nil, ValueError(fmt.Sprintf("Unexpected value type: %T", val))
+	}
+}
+
+func CompoundValue(val map[string]interface{}) (*pb.CompoundValue, error) {
+	kvpairs := make([]*pb.KeyValuePair, 0, len(val))
+	for k, v := range val {
+		sv, err := SimpleValue(v)
+		if err != nil {
+			return nil, err
+		}
+		kvpairs = append(kvpairs, &pb.KeyValuePair{k, sv})
+	}
+	return &pb.CompoundValue{kvpairs}, nil
 }

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -166,6 +166,57 @@ func (node *Node) httpQuery(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// POST /query/{peerId}
+// DATA: MCQL SELECT query
+// Queries a remote peer and returns the result set in ndjson
+func (node *Node) httpRemoteQuery(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	peerId := vars["peerId"]
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("http/query: Error reading request body: %s", err.Error())
+		return
+	}
+
+	q := string(body)
+
+	qq, err := mcq.ParseQuery(q)
+	if err != nil {
+		apiError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if qq.Op != mcq.OpSelect {
+		apiError(w, http.StatusBadRequest, BadQuery)
+		return
+	}
+
+	pid, err := p2p_peer.IDB58Decode(peerId)
+	if err != nil {
+		apiError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	ch, err := node.doRemoteQuery(ctx, pid, q)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	enc := json.NewEncoder(w)
+	for obj := range ch {
+		err = enc.Encode(obj)
+		if err != nil {
+			log.Printf("Error encoding query result: %s", err.Error())
+			return
+		}
+	}
+}
+
 // POST /delete
 // DATA: MCQL DELTE query
 // Deletes statements from the statement db

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -53,6 +53,7 @@ func main() {
 	router.HandleFunc("/publish/{namespace}", node.httpPublish)
 	router.HandleFunc("/stmt/{statementId}", node.httpStatement)
 	router.HandleFunc("/query", node.httpQuery)
+	router.HandleFunc("/query/{peerId}", node.httpRemoteQuery)
 	router.HandleFunc("/delete", node.httpDelete)
 	router.HandleFunc("/status", node.httpStatus)
 	router.HandleFunc("/status/{state}", node.httpStatusSet)

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -19,8 +19,9 @@ type Node struct {
 	status    int
 	laddr     multiaddr.Multiaddr
 	host      p2p_host.Host
+	netCtx    context.Context
+	netCancel context.CancelFunc
 	dir       *p2p_pstore.PeerInfo
-	dirCancel context.CancelFunc
 	home      string
 	db        StatementDB
 	mx        sync.Mutex

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -76,16 +76,16 @@ func (node *Node) doPublish(ns string, body interface{}) (string, error) {
 	stmt.Timestamp = ts
 	switch body := body.(type) {
 	case *pb.SimpleStatement:
-		stmt.Body = &pb.Statement_Simple{body}
+		stmt.Body = &pb.StatementBody{&pb.StatementBody_Simple{body}}
 
 	case *pb.CompoundStatement:
-		stmt.Body = &pb.Statement_Compound{body}
+		stmt.Body = &pb.StatementBody{&pb.StatementBody_Compound{body}}
 
 	case *pb.EnvelopeStatement:
-		stmt.Body = &pb.Statement_Envelope{body}
+		stmt.Body = &pb.StatementBody{&pb.StatementBody_Envelope{body}}
 
 	case *pb.ArchiveStatement:
-		stmt.Body = &pb.Statement_Archive{body}
+		stmt.Body = &pb.StatementBody{&pb.StatementBody_Archive{body}}
 
 	default:
 		return "", BadStatementBody

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -202,6 +202,11 @@ func (node *Node) queryHandler(s p2p_net.Stream) {
 			return
 		}
 
+		if q.Op != mcq.OpSelect {
+			writeError(BadQuery)
+			return
+		}
+
 		ch, err := node.db.QueryStream(ctx, q)
 		if err != nil {
 			writeError(err)

--- a/proto/dir.pb.go
+++ b/proto/dir.pb.go
@@ -19,7 +19,16 @@ It has these top-level messages:
 	ListPeersResponse
 	Ping
 	Pong
+	QueryRequest
+	QueryResult
+	QueryResultEnd
+	QueryResultError
+	QueryResultValue
+	SimpleValue
+	CompoundValue
+	KeyValuePair
 	Statement
+	StatementBody
 	SimpleStatement
 	CompoundStatement
 	EnvelopeStatement

--- a/proto/node.pb.go
+++ b/proto/node.pb.go
@@ -30,17 +30,553 @@ func (m *Pong) String() string            { return proto1.CompactTextString(m) }
 func (*Pong) ProtoMessage()               {}
 func (*Pong) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{1} }
 
+// node/query
+type QueryRequest struct {
+	Query string `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
+}
+
+func (m *QueryRequest) Reset()                    { *m = QueryRequest{} }
+func (m *QueryRequest) String() string            { return proto1.CompactTextString(m) }
+func (*QueryRequest) ProtoMessage()               {}
+func (*QueryRequest) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{2} }
+
+type QueryResult struct {
+	// Types that are valid to be assigned to Result:
+	//	*QueryResult_Value
+	//	*QueryResult_End
+	//	*QueryResult_Error
+	Result isQueryResult_Result `protobuf_oneof:"result"`
+}
+
+func (m *QueryResult) Reset()                    { *m = QueryResult{} }
+func (m *QueryResult) String() string            { return proto1.CompactTextString(m) }
+func (*QueryResult) ProtoMessage()               {}
+func (*QueryResult) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{3} }
+
+type isQueryResult_Result interface {
+	isQueryResult_Result()
+}
+
+type QueryResult_Value struct {
+	Value *QueryResultValue `protobuf:"bytes,1,opt,name=value,oneof"`
+}
+type QueryResult_End struct {
+	End *QueryResultEnd `protobuf:"bytes,2,opt,name=end,oneof"`
+}
+type QueryResult_Error struct {
+	Error *QueryResultError `protobuf:"bytes,3,opt,name=error,oneof"`
+}
+
+func (*QueryResult_Value) isQueryResult_Result() {}
+func (*QueryResult_End) isQueryResult_Result()   {}
+func (*QueryResult_Error) isQueryResult_Result() {}
+
+func (m *QueryResult) GetResult() isQueryResult_Result {
+	if m != nil {
+		return m.Result
+	}
+	return nil
+}
+
+func (m *QueryResult) GetValue() *QueryResultValue {
+	if x, ok := m.GetResult().(*QueryResult_Value); ok {
+		return x.Value
+	}
+	return nil
+}
+
+func (m *QueryResult) GetEnd() *QueryResultEnd {
+	if x, ok := m.GetResult().(*QueryResult_End); ok {
+		return x.End
+	}
+	return nil
+}
+
+func (m *QueryResult) GetError() *QueryResultError {
+	if x, ok := m.GetResult().(*QueryResult_Error); ok {
+		return x.Error
+	}
+	return nil
+}
+
+// XXX_OneofFuncs is for the internal use of the proto package.
+func (*QueryResult) XXX_OneofFuncs() (func(msg proto1.Message, b *proto1.Buffer) error, func(msg proto1.Message, tag, wire int, b *proto1.Buffer) (bool, error), func(msg proto1.Message) (n int), []interface{}) {
+	return _QueryResult_OneofMarshaler, _QueryResult_OneofUnmarshaler, _QueryResult_OneofSizer, []interface{}{
+		(*QueryResult_Value)(nil),
+		(*QueryResult_End)(nil),
+		(*QueryResult_Error)(nil),
+	}
+}
+
+func _QueryResult_OneofMarshaler(msg proto1.Message, b *proto1.Buffer) error {
+	m := msg.(*QueryResult)
+	// result
+	switch x := m.Result.(type) {
+	case *QueryResult_Value:
+		_ = b.EncodeVarint(1<<3 | proto1.WireBytes)
+		if err := b.EncodeMessage(x.Value); err != nil {
+			return err
+		}
+	case *QueryResult_End:
+		_ = b.EncodeVarint(2<<3 | proto1.WireBytes)
+		if err := b.EncodeMessage(x.End); err != nil {
+			return err
+		}
+	case *QueryResult_Error:
+		_ = b.EncodeVarint(3<<3 | proto1.WireBytes)
+		if err := b.EncodeMessage(x.Error); err != nil {
+			return err
+		}
+	case nil:
+	default:
+		return fmt.Errorf("QueryResult.Result has unexpected type %T", x)
+	}
+	return nil
+}
+
+func _QueryResult_OneofUnmarshaler(msg proto1.Message, tag, wire int, b *proto1.Buffer) (bool, error) {
+	m := msg.(*QueryResult)
+	switch tag {
+	case 1: // result.value
+		if wire != proto1.WireBytes {
+			return true, proto1.ErrInternalBadWireType
+		}
+		msg := new(QueryResultValue)
+		err := b.DecodeMessage(msg)
+		m.Result = &QueryResult_Value{msg}
+		return true, err
+	case 2: // result.end
+		if wire != proto1.WireBytes {
+			return true, proto1.ErrInternalBadWireType
+		}
+		msg := new(QueryResultEnd)
+		err := b.DecodeMessage(msg)
+		m.Result = &QueryResult_End{msg}
+		return true, err
+	case 3: // result.error
+		if wire != proto1.WireBytes {
+			return true, proto1.ErrInternalBadWireType
+		}
+		msg := new(QueryResultError)
+		err := b.DecodeMessage(msg)
+		m.Result = &QueryResult_Error{msg}
+		return true, err
+	default:
+		return false, nil
+	}
+}
+
+func _QueryResult_OneofSizer(msg proto1.Message) (n int) {
+	m := msg.(*QueryResult)
+	// result
+	switch x := m.Result.(type) {
+	case *QueryResult_Value:
+		s := proto1.Size(x.Value)
+		n += proto1.SizeVarint(1<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(uint64(s))
+		n += s
+	case *QueryResult_End:
+		s := proto1.Size(x.End)
+		n += proto1.SizeVarint(2<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(uint64(s))
+		n += s
+	case *QueryResult_Error:
+		s := proto1.Size(x.Error)
+		n += proto1.SizeVarint(3<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(uint64(s))
+		n += s
+	case nil:
+	default:
+		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
+	}
+	return n
+}
+
+type QueryResultEnd struct {
+}
+
+func (m *QueryResultEnd) Reset()                    { *m = QueryResultEnd{} }
+func (m *QueryResultEnd) String() string            { return proto1.CompactTextString(m) }
+func (*QueryResultEnd) ProtoMessage()               {}
+func (*QueryResultEnd) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{4} }
+
+type QueryResultError struct {
+	Error string `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"`
+}
+
+func (m *QueryResultError) Reset()                    { *m = QueryResultError{} }
+func (m *QueryResultError) String() string            { return proto1.CompactTextString(m) }
+func (*QueryResultError) ProtoMessage()               {}
+func (*QueryResultError) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{5} }
+
+type QueryResultValue struct {
+	// Types that are valid to be assigned to Value:
+	//	*QueryResultValue_Simple
+	//	*QueryResultValue_Compound
+	Value isQueryResultValue_Value `protobuf_oneof:"value"`
+}
+
+func (m *QueryResultValue) Reset()                    { *m = QueryResultValue{} }
+func (m *QueryResultValue) String() string            { return proto1.CompactTextString(m) }
+func (*QueryResultValue) ProtoMessage()               {}
+func (*QueryResultValue) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{6} }
+
+type isQueryResultValue_Value interface {
+	isQueryResultValue_Value()
+}
+
+type QueryResultValue_Simple struct {
+	Simple *SimpleValue `protobuf:"bytes,1,opt,name=simple,oneof"`
+}
+type QueryResultValue_Compound struct {
+	Compound *CompoundValue `protobuf:"bytes,2,opt,name=compound,oneof"`
+}
+
+func (*QueryResultValue_Simple) isQueryResultValue_Value()   {}
+func (*QueryResultValue_Compound) isQueryResultValue_Value() {}
+
+func (m *QueryResultValue) GetValue() isQueryResultValue_Value {
+	if m != nil {
+		return m.Value
+	}
+	return nil
+}
+
+func (m *QueryResultValue) GetSimple() *SimpleValue {
+	if x, ok := m.GetValue().(*QueryResultValue_Simple); ok {
+		return x.Simple
+	}
+	return nil
+}
+
+func (m *QueryResultValue) GetCompound() *CompoundValue {
+	if x, ok := m.GetValue().(*QueryResultValue_Compound); ok {
+		return x.Compound
+	}
+	return nil
+}
+
+// XXX_OneofFuncs is for the internal use of the proto package.
+func (*QueryResultValue) XXX_OneofFuncs() (func(msg proto1.Message, b *proto1.Buffer) error, func(msg proto1.Message, tag, wire int, b *proto1.Buffer) (bool, error), func(msg proto1.Message) (n int), []interface{}) {
+	return _QueryResultValue_OneofMarshaler, _QueryResultValue_OneofUnmarshaler, _QueryResultValue_OneofSizer, []interface{}{
+		(*QueryResultValue_Simple)(nil),
+		(*QueryResultValue_Compound)(nil),
+	}
+}
+
+func _QueryResultValue_OneofMarshaler(msg proto1.Message, b *proto1.Buffer) error {
+	m := msg.(*QueryResultValue)
+	// value
+	switch x := m.Value.(type) {
+	case *QueryResultValue_Simple:
+		_ = b.EncodeVarint(1<<3 | proto1.WireBytes)
+		if err := b.EncodeMessage(x.Simple); err != nil {
+			return err
+		}
+	case *QueryResultValue_Compound:
+		_ = b.EncodeVarint(2<<3 | proto1.WireBytes)
+		if err := b.EncodeMessage(x.Compound); err != nil {
+			return err
+		}
+	case nil:
+	default:
+		return fmt.Errorf("QueryResultValue.Value has unexpected type %T", x)
+	}
+	return nil
+}
+
+func _QueryResultValue_OneofUnmarshaler(msg proto1.Message, tag, wire int, b *proto1.Buffer) (bool, error) {
+	m := msg.(*QueryResultValue)
+	switch tag {
+	case 1: // value.simple
+		if wire != proto1.WireBytes {
+			return true, proto1.ErrInternalBadWireType
+		}
+		msg := new(SimpleValue)
+		err := b.DecodeMessage(msg)
+		m.Value = &QueryResultValue_Simple{msg}
+		return true, err
+	case 2: // value.compound
+		if wire != proto1.WireBytes {
+			return true, proto1.ErrInternalBadWireType
+		}
+		msg := new(CompoundValue)
+		err := b.DecodeMessage(msg)
+		m.Value = &QueryResultValue_Compound{msg}
+		return true, err
+	default:
+		return false, nil
+	}
+}
+
+func _QueryResultValue_OneofSizer(msg proto1.Message) (n int) {
+	m := msg.(*QueryResultValue)
+	// value
+	switch x := m.Value.(type) {
+	case *QueryResultValue_Simple:
+		s := proto1.Size(x.Simple)
+		n += proto1.SizeVarint(1<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(uint64(s))
+		n += s
+	case *QueryResultValue_Compound:
+		s := proto1.Size(x.Compound)
+		n += proto1.SizeVarint(2<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(uint64(s))
+		n += s
+	case nil:
+	default:
+		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
+	}
+	return n
+}
+
+type SimpleValue struct {
+	// Types that are valid to be assigned to Value:
+	//	*SimpleValue_IntValue
+	//	*SimpleValue_StringValue
+	//	*SimpleValue_Stmt
+	//	*SimpleValue_StmtBody
+	Value isSimpleValue_Value `protobuf_oneof:"value"`
+}
+
+func (m *SimpleValue) Reset()                    { *m = SimpleValue{} }
+func (m *SimpleValue) String() string            { return proto1.CompactTextString(m) }
+func (*SimpleValue) ProtoMessage()               {}
+func (*SimpleValue) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{7} }
+
+type isSimpleValue_Value interface {
+	isSimpleValue_Value()
+}
+
+type SimpleValue_IntValue struct {
+	IntValue int64 `protobuf:"varint,1,opt,name=intValue,proto3,oneof"`
+}
+type SimpleValue_StringValue struct {
+	StringValue string `protobuf:"bytes,2,opt,name=stringValue,proto3,oneof"`
+}
+type SimpleValue_Stmt struct {
+	Stmt *Statement `protobuf:"bytes,3,opt,name=stmt,oneof"`
+}
+type SimpleValue_StmtBody struct {
+	StmtBody *StatementBody `protobuf:"bytes,4,opt,name=stmtBody,oneof"`
+}
+
+func (*SimpleValue_IntValue) isSimpleValue_Value()    {}
+func (*SimpleValue_StringValue) isSimpleValue_Value() {}
+func (*SimpleValue_Stmt) isSimpleValue_Value()        {}
+func (*SimpleValue_StmtBody) isSimpleValue_Value()    {}
+
+func (m *SimpleValue) GetValue() isSimpleValue_Value {
+	if m != nil {
+		return m.Value
+	}
+	return nil
+}
+
+func (m *SimpleValue) GetIntValue() int64 {
+	if x, ok := m.GetValue().(*SimpleValue_IntValue); ok {
+		return x.IntValue
+	}
+	return 0
+}
+
+func (m *SimpleValue) GetStringValue() string {
+	if x, ok := m.GetValue().(*SimpleValue_StringValue); ok {
+		return x.StringValue
+	}
+	return ""
+}
+
+func (m *SimpleValue) GetStmt() *Statement {
+	if x, ok := m.GetValue().(*SimpleValue_Stmt); ok {
+		return x.Stmt
+	}
+	return nil
+}
+
+func (m *SimpleValue) GetStmtBody() *StatementBody {
+	if x, ok := m.GetValue().(*SimpleValue_StmtBody); ok {
+		return x.StmtBody
+	}
+	return nil
+}
+
+// XXX_OneofFuncs is for the internal use of the proto package.
+func (*SimpleValue) XXX_OneofFuncs() (func(msg proto1.Message, b *proto1.Buffer) error, func(msg proto1.Message, tag, wire int, b *proto1.Buffer) (bool, error), func(msg proto1.Message) (n int), []interface{}) {
+	return _SimpleValue_OneofMarshaler, _SimpleValue_OneofUnmarshaler, _SimpleValue_OneofSizer, []interface{}{
+		(*SimpleValue_IntValue)(nil),
+		(*SimpleValue_StringValue)(nil),
+		(*SimpleValue_Stmt)(nil),
+		(*SimpleValue_StmtBody)(nil),
+	}
+}
+
+func _SimpleValue_OneofMarshaler(msg proto1.Message, b *proto1.Buffer) error {
+	m := msg.(*SimpleValue)
+	// value
+	switch x := m.Value.(type) {
+	case *SimpleValue_IntValue:
+		_ = b.EncodeVarint(1<<3 | proto1.WireVarint)
+		_ = b.EncodeVarint(uint64(x.IntValue))
+	case *SimpleValue_StringValue:
+		_ = b.EncodeVarint(2<<3 | proto1.WireBytes)
+		_ = b.EncodeStringBytes(x.StringValue)
+	case *SimpleValue_Stmt:
+		_ = b.EncodeVarint(3<<3 | proto1.WireBytes)
+		if err := b.EncodeMessage(x.Stmt); err != nil {
+			return err
+		}
+	case *SimpleValue_StmtBody:
+		_ = b.EncodeVarint(4<<3 | proto1.WireBytes)
+		if err := b.EncodeMessage(x.StmtBody); err != nil {
+			return err
+		}
+	case nil:
+	default:
+		return fmt.Errorf("SimpleValue.Value has unexpected type %T", x)
+	}
+	return nil
+}
+
+func _SimpleValue_OneofUnmarshaler(msg proto1.Message, tag, wire int, b *proto1.Buffer) (bool, error) {
+	m := msg.(*SimpleValue)
+	switch tag {
+	case 1: // value.intValue
+		if wire != proto1.WireVarint {
+			return true, proto1.ErrInternalBadWireType
+		}
+		x, err := b.DecodeVarint()
+		m.Value = &SimpleValue_IntValue{int64(x)}
+		return true, err
+	case 2: // value.stringValue
+		if wire != proto1.WireBytes {
+			return true, proto1.ErrInternalBadWireType
+		}
+		x, err := b.DecodeStringBytes()
+		m.Value = &SimpleValue_StringValue{x}
+		return true, err
+	case 3: // value.stmt
+		if wire != proto1.WireBytes {
+			return true, proto1.ErrInternalBadWireType
+		}
+		msg := new(Statement)
+		err := b.DecodeMessage(msg)
+		m.Value = &SimpleValue_Stmt{msg}
+		return true, err
+	case 4: // value.stmtBody
+		if wire != proto1.WireBytes {
+			return true, proto1.ErrInternalBadWireType
+		}
+		msg := new(StatementBody)
+		err := b.DecodeMessage(msg)
+		m.Value = &SimpleValue_StmtBody{msg}
+		return true, err
+	default:
+		return false, nil
+	}
+}
+
+func _SimpleValue_OneofSizer(msg proto1.Message) (n int) {
+	m := msg.(*SimpleValue)
+	// value
+	switch x := m.Value.(type) {
+	case *SimpleValue_IntValue:
+		n += proto1.SizeVarint(1<<3 | proto1.WireVarint)
+		n += proto1.SizeVarint(uint64(x.IntValue))
+	case *SimpleValue_StringValue:
+		n += proto1.SizeVarint(2<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(uint64(len(x.StringValue)))
+		n += len(x.StringValue)
+	case *SimpleValue_Stmt:
+		s := proto1.Size(x.Stmt)
+		n += proto1.SizeVarint(3<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(uint64(s))
+		n += s
+	case *SimpleValue_StmtBody:
+		s := proto1.Size(x.StmtBody)
+		n += proto1.SizeVarint(4<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(uint64(s))
+		n += s
+	case nil:
+	default:
+		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
+	}
+	return n
+}
+
+type CompoundValue struct {
+	Body []*KeyValuePair `protobuf:"bytes,1,rep,name=body" json:"body,omitempty"`
+}
+
+func (m *CompoundValue) Reset()                    { *m = CompoundValue{} }
+func (m *CompoundValue) String() string            { return proto1.CompactTextString(m) }
+func (*CompoundValue) ProtoMessage()               {}
+func (*CompoundValue) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{8} }
+
+func (m *CompoundValue) GetBody() []*KeyValuePair {
+	if m != nil {
+		return m.Body
+	}
+	return nil
+}
+
+type KeyValuePair struct {
+	Key   string       `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value *SimpleValue `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"`
+}
+
+func (m *KeyValuePair) Reset()                    { *m = KeyValuePair{} }
+func (m *KeyValuePair) String() string            { return proto1.CompactTextString(m) }
+func (*KeyValuePair) ProtoMessage()               {}
+func (*KeyValuePair) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{9} }
+
+func (m *KeyValuePair) GetValue() *SimpleValue {
+	if m != nil {
+		return m.Value
+	}
+	return nil
+}
+
 func init() {
 	proto1.RegisterType((*Ping)(nil), "proto.Ping")
 	proto1.RegisterType((*Pong)(nil), "proto.Pong")
+	proto1.RegisterType((*QueryRequest)(nil), "proto.QueryRequest")
+	proto1.RegisterType((*QueryResult)(nil), "proto.QueryResult")
+	proto1.RegisterType((*QueryResultEnd)(nil), "proto.QueryResultEnd")
+	proto1.RegisterType((*QueryResultError)(nil), "proto.QueryResultError")
+	proto1.RegisterType((*QueryResultValue)(nil), "proto.QueryResultValue")
+	proto1.RegisterType((*SimpleValue)(nil), "proto.SimpleValue")
+	proto1.RegisterType((*CompoundValue)(nil), "proto.CompoundValue")
+	proto1.RegisterType((*KeyValuePair)(nil), "proto.KeyValuePair")
 }
 
 func init() { proto1.RegisterFile("node.proto", fileDescriptorNode) }
 
 var fileDescriptorNode = []byte{
-	// 57 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0xe2, 0xe2, 0xca, 0xcb, 0x4f, 0x49,
-	0xd5, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62, 0x05, 0x53, 0x4a, 0x6c, 0x5c, 0x2c, 0x01, 0x99,
-	0x79, 0xe9, 0x60, 0x3a, 0x3f, 0x2f, 0x3d, 0x89, 0x0d, 0x2c, 0x6c, 0x0c, 0x08, 0x00, 0x00, 0xff,
-	0xff, 0xfe, 0xe2, 0xf3, 0xe8, 0x2b, 0x00, 0x00, 0x00,
+	// 386 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0x74, 0x92, 0x41, 0x6b, 0xdb, 0x30,
+	0x14, 0xc7, 0xed, 0xd8, 0xf1, 0x92, 0xe7, 0x6c, 0x18, 0x2d, 0x63, 0x66, 0xec, 0x10, 0xc4, 0xd8,
+	0x3c, 0x28, 0x29, 0xa4, 0x97, 0x9e, 0x53, 0x02, 0xa6, 0xbd, 0xa4, 0x2e, 0xf4, 0x9e, 0xd4, 0x22,
+	0x98, 0xc6, 0x52, 0x22, 0xcb, 0x85, 0x1c, 0xfa, 0x6d, 0xfa, 0x11, 0xfa, 0x01, 0xcb, 0x93, 0xa5,
+	0xd4, 0x6e, 0xc9, 0x49, 0xd6, 0xff, 0xfd, 0xf4, 0x7f, 0xff, 0x27, 0x0b, 0x80, 0x8b, 0x9c, 0x4d,
+	0x77, 0x52, 0x28, 0x41, 0xfa, 0x7a, 0xf9, 0x05, 0x95, 0x2a, 0x55, 0x23, 0xd1, 0x00, 0xfc, 0x65,
+	0xc1, 0x37, 0x7a, 0x15, 0x7c, 0x43, 0xff, 0xc0, 0xe8, 0xb6, 0x66, 0xf2, 0x90, 0xb1, 0x7d, 0xcd,
+	0x2a, 0x45, 0xc6, 0xd0, 0xdf, 0xe3, 0x3e, 0x76, 0x27, 0x6e, 0x32, 0xcc, 0x9a, 0x0d, 0x7d, 0x71,
+	0x21, 0x34, 0x58, 0x55, 0x6f, 0x15, 0x39, 0x87, 0xfe, 0xd3, 0x6a, 0x5b, 0x33, 0x4d, 0x85, 0xb3,
+	0x9f, 0x8d, 0xf9, 0xb4, 0x85, 0xdc, 0x63, 0x39, 0x75, 0xb2, 0x86, 0x23, 0xff, 0xc1, 0x63, 0x3c,
+	0x8f, 0x7b, 0x1a, 0xff, 0xf1, 0x19, 0x5f, 0xf0, 0x3c, 0x75, 0x32, 0x64, 0xd0, 0x9b, 0x49, 0x29,
+	0x64, 0xec, 0x9d, 0xf2, 0x5e, 0x60, 0x19, 0xbd, 0x35, 0x37, 0x1f, 0x40, 0x20, 0xb5, 0x4e, 0x23,
+	0xf8, 0xd6, 0xf5, 0xa4, 0x09, 0x44, 0x1f, 0x0f, 0xe2, 0x88, 0x4d, 0x03, 0x33, 0xa2, 0xde, 0xd0,
+	0xe7, 0x0e, 0xa9, 0xe3, 0x93, 0x33, 0x08, 0xaa, 0xa2, 0xdc, 0x6d, 0xed, 0x9c, 0xc4, 0x64, 0xb9,
+	0xd3, 0xa2, 0x1d, 0xd1, 0x30, 0x64, 0x06, 0x83, 0x07, 0x51, 0xee, 0x44, 0x7d, 0x1c, 0x74, 0x6c,
+	0xf8, 0x2b, 0x23, 0xdb, 0x13, 0x47, 0x6e, 0xfe, 0xc5, 0x5c, 0x24, 0x7d, 0x75, 0x21, 0x6c, 0xd9,
+	0x92, 0xdf, 0x30, 0x28, 0x78, 0x13, 0x43, 0x37, 0xf7, 0xf0, 0x98, 0x55, 0x08, 0x85, 0xb0, 0x52,
+	0xb2, 0xe0, 0x9b, 0x06, 0xc0, 0x6e, 0xc3, 0xd4, 0xc9, 0xda, 0x22, 0xf9, 0x0b, 0x3e, 0xfe, 0x77,
+	0x73, 0x8d, 0x91, 0x8d, 0xae, 0x56, 0x8a, 0x95, 0x8c, 0xab, 0xd4, 0xc9, 0x74, 0x1d, 0x63, 0xe3,
+	0x3a, 0x17, 0xf9, 0x21, 0xf6, 0x3b, 0xb1, 0x8f, 0x2c, 0xd6, 0xb0, 0xbf, 0xe5, 0xde, 0x63, 0x5f,
+	0xc2, 0xd7, 0xce, 0x70, 0xe4, 0x1f, 0xf8, 0x6b, 0x74, 0x72, 0x27, 0x5e, 0x12, 0xce, 0xbe, 0x1b,
+	0xa7, 0x1b, 0x76, 0xd0, 0xe5, 0xe5, 0xaa, 0x90, 0x99, 0x06, 0xe8, 0x35, 0x8c, 0xda, 0x2a, 0x89,
+	0xc0, 0x7b, 0x64, 0xf6, 0xd9, 0xe1, 0x27, 0x49, 0xec, 0x23, 0xeb, 0x9d, 0xba, 0x7c, 0xf3, 0xba,
+	0xd6, 0x81, 0xae, 0x5c, 0xbc, 0x05, 0x00, 0x00, 0xff, 0xff, 0x21, 0x5c, 0x63, 0x0f, 0xfc, 0x02,
+	0x00, 0x00,
 }

--- a/proto/node.proto
+++ b/proto/node.proto
@@ -1,7 +1,54 @@
 syntax = "proto3";
 package proto;
 
+import "stmt.proto";
+
 // node/ping
 message Ping {}
 message Pong {}
+
+// node/query
+message QueryRequest {
+  string query = 1;
+}
+
+message QueryResult {
+  oneof result {
+    QueryResultValue value = 1;
+    QueryResultEnd end = 2;
+    QueryResultError error = 3;
+  }
+}
+
+message QueryResultEnd {}
+
+message QueryResultError {
+  string error = 1;
+}
+
+message QueryResultValue {
+  oneof value {
+    SimpleValue simple = 1;
+    CompoundValue compound = 2;
+  }
+}
+
+message SimpleValue {
+  oneof value {
+    int64 intValue = 1;
+    string stringValue = 2;
+    Statement stmt = 3;
+    StatementBody stmtBody = 4;
+  }
+}
+
+message CompoundValue {
+  repeated KeyValuePair body = 1;
+}
+
+message KeyValuePair {
+  string key = 1;
+  SimpleValue value = 2;
+}
+
 

--- a/proto/stmt.pb.go
+++ b/proto/stmt.pb.go
@@ -14,17 +14,12 @@ var _ = fmt.Errorf
 var _ = math.Inf
 
 type Statement struct {
-	Id        string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Publisher string `protobuf:"bytes,2,opt,name=publisher,proto3" json:"publisher,omitempty"`
-	Namespace string `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
-	// Types that are valid to be assigned to Body:
-	//	*Statement_Simple
-	//	*Statement_Compound
-	//	*Statement_Envelope
-	//	*Statement_Archive
-	Body      isStatement_Body `protobuf_oneof:"body"`
-	Timestamp int64            `protobuf:"varint,8,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	Signature []byte           `protobuf:"bytes,9,opt,name=signature,proto3" json:"signature,omitempty"`
+	Id        string         `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Publisher string         `protobuf:"bytes,2,opt,name=publisher,proto3" json:"publisher,omitempty"`
+	Namespace string         `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Body      *StatementBody `protobuf:"bytes,4,opt,name=body" json:"body,omitempty"`
+	Timestamp int64          `protobuf:"varint,5,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Signature []byte         `protobuf:"bytes,6,opt,name=signature,proto3" json:"signature,omitempty"`
 }
 
 func (m *Statement) Reset()                    { *m = Statement{} }
@@ -32,166 +27,187 @@ func (m *Statement) String() string            { return proto1.CompactTextString
 func (*Statement) ProtoMessage()               {}
 func (*Statement) Descriptor() ([]byte, []int) { return fileDescriptorStmt, []int{0} }
 
-type isStatement_Body interface {
-	isStatement_Body()
-}
-
-type Statement_Simple struct {
-	Simple *SimpleStatement `protobuf:"bytes,4,opt,name=simple,oneof"`
-}
-type Statement_Compound struct {
-	Compound *CompoundStatement `protobuf:"bytes,5,opt,name=compound,oneof"`
-}
-type Statement_Envelope struct {
-	Envelope *EnvelopeStatement `protobuf:"bytes,6,opt,name=envelope,oneof"`
-}
-type Statement_Archive struct {
-	Archive *ArchiveStatement `protobuf:"bytes,7,opt,name=archive,oneof"`
-}
-
-func (*Statement_Simple) isStatement_Body()   {}
-func (*Statement_Compound) isStatement_Body() {}
-func (*Statement_Envelope) isStatement_Body() {}
-func (*Statement_Archive) isStatement_Body()  {}
-
-func (m *Statement) GetBody() isStatement_Body {
+func (m *Statement) GetBody() *StatementBody {
 	if m != nil {
 		return m.Body
 	}
 	return nil
 }
 
-func (m *Statement) GetSimple() *SimpleStatement {
-	if x, ok := m.GetBody().(*Statement_Simple); ok {
+type StatementBody struct {
+	// Types that are valid to be assigned to Body:
+	//	*StatementBody_Simple
+	//	*StatementBody_Compound
+	//	*StatementBody_Envelope
+	//	*StatementBody_Archive
+	Body isStatementBody_Body `protobuf_oneof:"body"`
+}
+
+func (m *StatementBody) Reset()                    { *m = StatementBody{} }
+func (m *StatementBody) String() string            { return proto1.CompactTextString(m) }
+func (*StatementBody) ProtoMessage()               {}
+func (*StatementBody) Descriptor() ([]byte, []int) { return fileDescriptorStmt, []int{1} }
+
+type isStatementBody_Body interface {
+	isStatementBody_Body()
+}
+
+type StatementBody_Simple struct {
+	Simple *SimpleStatement `protobuf:"bytes,1,opt,name=simple,oneof"`
+}
+type StatementBody_Compound struct {
+	Compound *CompoundStatement `protobuf:"bytes,2,opt,name=compound,oneof"`
+}
+type StatementBody_Envelope struct {
+	Envelope *EnvelopeStatement `protobuf:"bytes,3,opt,name=envelope,oneof"`
+}
+type StatementBody_Archive struct {
+	Archive *ArchiveStatement `protobuf:"bytes,4,opt,name=archive,oneof"`
+}
+
+func (*StatementBody_Simple) isStatementBody_Body()   {}
+func (*StatementBody_Compound) isStatementBody_Body() {}
+func (*StatementBody_Envelope) isStatementBody_Body() {}
+func (*StatementBody_Archive) isStatementBody_Body()  {}
+
+func (m *StatementBody) GetBody() isStatementBody_Body {
+	if m != nil {
+		return m.Body
+	}
+	return nil
+}
+
+func (m *StatementBody) GetSimple() *SimpleStatement {
+	if x, ok := m.GetBody().(*StatementBody_Simple); ok {
 		return x.Simple
 	}
 	return nil
 }
 
-func (m *Statement) GetCompound() *CompoundStatement {
-	if x, ok := m.GetBody().(*Statement_Compound); ok {
+func (m *StatementBody) GetCompound() *CompoundStatement {
+	if x, ok := m.GetBody().(*StatementBody_Compound); ok {
 		return x.Compound
 	}
 	return nil
 }
 
-func (m *Statement) GetEnvelope() *EnvelopeStatement {
-	if x, ok := m.GetBody().(*Statement_Envelope); ok {
+func (m *StatementBody) GetEnvelope() *EnvelopeStatement {
+	if x, ok := m.GetBody().(*StatementBody_Envelope); ok {
 		return x.Envelope
 	}
 	return nil
 }
 
-func (m *Statement) GetArchive() *ArchiveStatement {
-	if x, ok := m.GetBody().(*Statement_Archive); ok {
+func (m *StatementBody) GetArchive() *ArchiveStatement {
+	if x, ok := m.GetBody().(*StatementBody_Archive); ok {
 		return x.Archive
 	}
 	return nil
 }
 
 // XXX_OneofFuncs is for the internal use of the proto package.
-func (*Statement) XXX_OneofFuncs() (func(msg proto1.Message, b *proto1.Buffer) error, func(msg proto1.Message, tag, wire int, b *proto1.Buffer) (bool, error), func(msg proto1.Message) (n int), []interface{}) {
-	return _Statement_OneofMarshaler, _Statement_OneofUnmarshaler, _Statement_OneofSizer, []interface{}{
-		(*Statement_Simple)(nil),
-		(*Statement_Compound)(nil),
-		(*Statement_Envelope)(nil),
-		(*Statement_Archive)(nil),
+func (*StatementBody) XXX_OneofFuncs() (func(msg proto1.Message, b *proto1.Buffer) error, func(msg proto1.Message, tag, wire int, b *proto1.Buffer) (bool, error), func(msg proto1.Message) (n int), []interface{}) {
+	return _StatementBody_OneofMarshaler, _StatementBody_OneofUnmarshaler, _StatementBody_OneofSizer, []interface{}{
+		(*StatementBody_Simple)(nil),
+		(*StatementBody_Compound)(nil),
+		(*StatementBody_Envelope)(nil),
+		(*StatementBody_Archive)(nil),
 	}
 }
 
-func _Statement_OneofMarshaler(msg proto1.Message, b *proto1.Buffer) error {
-	m := msg.(*Statement)
+func _StatementBody_OneofMarshaler(msg proto1.Message, b *proto1.Buffer) error {
+	m := msg.(*StatementBody)
 	// body
 	switch x := m.Body.(type) {
-	case *Statement_Simple:
-		_ = b.EncodeVarint(4<<3 | proto1.WireBytes)
+	case *StatementBody_Simple:
+		_ = b.EncodeVarint(1<<3 | proto1.WireBytes)
 		if err := b.EncodeMessage(x.Simple); err != nil {
 			return err
 		}
-	case *Statement_Compound:
-		_ = b.EncodeVarint(5<<3 | proto1.WireBytes)
+	case *StatementBody_Compound:
+		_ = b.EncodeVarint(2<<3 | proto1.WireBytes)
 		if err := b.EncodeMessage(x.Compound); err != nil {
 			return err
 		}
-	case *Statement_Envelope:
-		_ = b.EncodeVarint(6<<3 | proto1.WireBytes)
+	case *StatementBody_Envelope:
+		_ = b.EncodeVarint(3<<3 | proto1.WireBytes)
 		if err := b.EncodeMessage(x.Envelope); err != nil {
 			return err
 		}
-	case *Statement_Archive:
-		_ = b.EncodeVarint(7<<3 | proto1.WireBytes)
+	case *StatementBody_Archive:
+		_ = b.EncodeVarint(4<<3 | proto1.WireBytes)
 		if err := b.EncodeMessage(x.Archive); err != nil {
 			return err
 		}
 	case nil:
 	default:
-		return fmt.Errorf("Statement.Body has unexpected type %T", x)
+		return fmt.Errorf("StatementBody.Body has unexpected type %T", x)
 	}
 	return nil
 }
 
-func _Statement_OneofUnmarshaler(msg proto1.Message, tag, wire int, b *proto1.Buffer) (bool, error) {
-	m := msg.(*Statement)
+func _StatementBody_OneofUnmarshaler(msg proto1.Message, tag, wire int, b *proto1.Buffer) (bool, error) {
+	m := msg.(*StatementBody)
 	switch tag {
-	case 4: // body.simple
+	case 1: // body.simple
 		if wire != proto1.WireBytes {
 			return true, proto1.ErrInternalBadWireType
 		}
 		msg := new(SimpleStatement)
 		err := b.DecodeMessage(msg)
-		m.Body = &Statement_Simple{msg}
+		m.Body = &StatementBody_Simple{msg}
 		return true, err
-	case 5: // body.compound
+	case 2: // body.compound
 		if wire != proto1.WireBytes {
 			return true, proto1.ErrInternalBadWireType
 		}
 		msg := new(CompoundStatement)
 		err := b.DecodeMessage(msg)
-		m.Body = &Statement_Compound{msg}
+		m.Body = &StatementBody_Compound{msg}
 		return true, err
-	case 6: // body.envelope
+	case 3: // body.envelope
 		if wire != proto1.WireBytes {
 			return true, proto1.ErrInternalBadWireType
 		}
 		msg := new(EnvelopeStatement)
 		err := b.DecodeMessage(msg)
-		m.Body = &Statement_Envelope{msg}
+		m.Body = &StatementBody_Envelope{msg}
 		return true, err
-	case 7: // body.archive
+	case 4: // body.archive
 		if wire != proto1.WireBytes {
 			return true, proto1.ErrInternalBadWireType
 		}
 		msg := new(ArchiveStatement)
 		err := b.DecodeMessage(msg)
-		m.Body = &Statement_Archive{msg}
+		m.Body = &StatementBody_Archive{msg}
 		return true, err
 	default:
 		return false, nil
 	}
 }
 
-func _Statement_OneofSizer(msg proto1.Message) (n int) {
-	m := msg.(*Statement)
+func _StatementBody_OneofSizer(msg proto1.Message) (n int) {
+	m := msg.(*StatementBody)
 	// body
 	switch x := m.Body.(type) {
-	case *Statement_Simple:
+	case *StatementBody_Simple:
 		s := proto1.Size(x.Simple)
-		n += proto1.SizeVarint(4<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(1<<3 | proto1.WireBytes)
 		n += proto1.SizeVarint(uint64(s))
 		n += s
-	case *Statement_Compound:
+	case *StatementBody_Compound:
 		s := proto1.Size(x.Compound)
-		n += proto1.SizeVarint(5<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(2<<3 | proto1.WireBytes)
 		n += proto1.SizeVarint(uint64(s))
 		n += s
-	case *Statement_Envelope:
+	case *StatementBody_Envelope:
 		s := proto1.Size(x.Envelope)
-		n += proto1.SizeVarint(6<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(3<<3 | proto1.WireBytes)
 		n += proto1.SizeVarint(uint64(s))
 		n += s
-	case *Statement_Archive:
+	case *StatementBody_Archive:
 		s := proto1.Size(x.Archive)
-		n += proto1.SizeVarint(7<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(4<<3 | proto1.WireBytes)
 		n += proto1.SizeVarint(uint64(s))
 		n += s
 	case nil:
@@ -210,7 +226,7 @@ type SimpleStatement struct {
 func (m *SimpleStatement) Reset()                    { *m = SimpleStatement{} }
 func (m *SimpleStatement) String() string            { return proto1.CompactTextString(m) }
 func (*SimpleStatement) ProtoMessage()               {}
-func (*SimpleStatement) Descriptor() ([]byte, []int) { return fileDescriptorStmt, []int{1} }
+func (*SimpleStatement) Descriptor() ([]byte, []int) { return fileDescriptorStmt, []int{2} }
 
 type CompoundStatement struct {
 	Body []*SimpleStatement `protobuf:"bytes,1,rep,name=body" json:"body,omitempty"`
@@ -219,7 +235,7 @@ type CompoundStatement struct {
 func (m *CompoundStatement) Reset()                    { *m = CompoundStatement{} }
 func (m *CompoundStatement) String() string            { return proto1.CompactTextString(m) }
 func (*CompoundStatement) ProtoMessage()               {}
-func (*CompoundStatement) Descriptor() ([]byte, []int) { return fileDescriptorStmt, []int{2} }
+func (*CompoundStatement) Descriptor() ([]byte, []int) { return fileDescriptorStmt, []int{3} }
 
 func (m *CompoundStatement) GetBody() []*SimpleStatement {
 	if m != nil {
@@ -235,7 +251,7 @@ type EnvelopeStatement struct {
 func (m *EnvelopeStatement) Reset()                    { *m = EnvelopeStatement{} }
 func (m *EnvelopeStatement) String() string            { return proto1.CompactTextString(m) }
 func (*EnvelopeStatement) ProtoMessage()               {}
-func (*EnvelopeStatement) Descriptor() ([]byte, []int) { return fileDescriptorStmt, []int{3} }
+func (*EnvelopeStatement) Descriptor() ([]byte, []int) { return fileDescriptorStmt, []int{4} }
 
 func (m *EnvelopeStatement) GetBody() []*Statement {
 	if m != nil {
@@ -250,10 +266,11 @@ type ArchiveStatement struct {
 func (m *ArchiveStatement) Reset()                    { *m = ArchiveStatement{} }
 func (m *ArchiveStatement) String() string            { return proto1.CompactTextString(m) }
 func (*ArchiveStatement) ProtoMessage()               {}
-func (*ArchiveStatement) Descriptor() ([]byte, []int) { return fileDescriptorStmt, []int{4} }
+func (*ArchiveStatement) Descriptor() ([]byte, []int) { return fileDescriptorStmt, []int{5} }
 
 func init() {
 	proto1.RegisterType((*Statement)(nil), "proto.Statement")
+	proto1.RegisterType((*StatementBody)(nil), "proto.StatementBody")
 	proto1.RegisterType((*SimpleStatement)(nil), "proto.SimpleStatement")
 	proto1.RegisterType((*CompoundStatement)(nil), "proto.CompoundStatement")
 	proto1.RegisterType((*EnvelopeStatement)(nil), "proto.EnvelopeStatement")
@@ -263,26 +280,28 @@ func init() {
 func init() { proto1.RegisterFile("stmt.proto", fileDescriptorStmt) }
 
 var fileDescriptorStmt = []byte{
-	// 328 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0x74, 0x91, 0x4d, 0x4b, 0xc3, 0x40,
-	0x10, 0x86, 0x4d, 0xd2, 0xa6, 0xcd, 0x28, 0xda, 0xee, 0xa1, 0xce, 0xc1, 0x43, 0x28, 0x1e, 0x82,
-	0x87, 0x22, 0x16, 0x04, 0x4f, 0xa2, 0x22, 0x78, 0x35, 0xfd, 0x05, 0xf9, 0x18, 0xdb, 0x95, 0x6e,
-	0x76, 0xc9, 0x6e, 0x0b, 0xfe, 0x6d, 0x7f, 0x81, 0x64, 0xb3, 0xfd, 0xc6, 0x53, 0xb7, 0xcf, 0xbc,
-	0xcf, 0x4e, 0xf2, 0x06, 0x40, 0x1b, 0x61, 0x26, 0xaa, 0x96, 0x46, 0xb2, 0xae, 0xfd, 0x19, 0xff,
-	0xfa, 0x10, 0xcd, 0x4c, 0x66, 0x48, 0x50, 0x65, 0xd8, 0x25, 0xf8, 0xbc, 0x44, 0x2f, 0xf6, 0x92,
-	0x28, 0xf5, 0x79, 0xc9, 0x6e, 0x20, 0x52, 0xab, 0x7c, 0xc9, 0xf5, 0x82, 0x6a, 0xf4, 0x2d, 0xde,
-	0x81, 0x66, 0x5a, 0x65, 0x82, 0xb4, 0xca, 0x0a, 0xc2, 0xa0, 0x9d, 0x6e, 0x01, 0xbb, 0x87, 0x50,
-	0x73, 0xa1, 0x96, 0x84, 0x9d, 0xd8, 0x4b, 0xce, 0x1f, 0x46, 0xed, 0xe2, 0xc9, 0xcc, 0xc2, 0xed,
-	0xce, 0x8f, 0xb3, 0xd4, 0xe5, 0xd8, 0x23, 0xf4, 0x0b, 0x29, 0x94, 0x5c, 0x55, 0x25, 0x76, 0xad,
-	0x83, 0xce, 0x79, 0x73, 0x78, 0xdf, 0xda, 0x66, 0x1b, 0x8f, 0xaa, 0x35, 0x2d, 0xa5, 0x22, 0x0c,
-	0x0f, 0xbc, 0x77, 0x87, 0x0f, 0xbc, 0x4d, 0x96, 0x4d, 0xa1, 0x97, 0xd5, 0xc5, 0x82, 0xaf, 0x09,
-	0x7b, 0x56, 0xbb, 0x76, 0xda, 0x4b, 0x4b, 0xf7, 0xad, 0x4d, 0xb2, 0x79, 0x69, 0xc3, 0x05, 0x69,
-	0x93, 0x09, 0x85, 0xfd, 0xd8, 0x4b, 0x82, 0x74, 0x07, 0x9a, 0xa9, 0xe6, 0xf3, 0x2a, 0x33, 0xab,
-	0x9a, 0x30, 0x8a, 0xbd, 0xe4, 0x22, 0xdd, 0x81, 0xd7, 0x10, 0x3a, 0xb9, 0x2c, 0x7f, 0xc6, 0x9f,
-	0x70, 0x75, 0xd4, 0x02, 0x1b, 0x41, 0x28, 0xf3, 0x6f, 0x2a, 0x8c, 0x6b, 0xdf, 0xfd, 0x63, 0x0c,
-	0x3a, 0x35, 0x7d, 0x69, 0xf4, 0xe3, 0x20, 0x89, 0x52, 0x7b, 0x6e, 0x98, 0xc9, 0xe6, 0x1a, 0x83,
-	0x96, 0x35, 0xe7, 0xf1, 0x33, 0x0c, 0x4f, 0x4a, 0x62, 0x77, 0xed, 0x3e, 0xf4, 0xe2, 0xe0, 0xff,
-	0x0f, 0x90, 0xb6, 0xcf, 0xf4, 0x04, 0xc3, 0x93, 0xb6, 0xd8, 0xed, 0xc1, 0x05, 0x83, 0xcd, 0x05,
-	0x47, 0x2a, 0x83, 0xc1, 0x71, 0x63, 0x79, 0x68, 0xa3, 0xd3, 0xbf, 0x00, 0x00, 0x00, 0xff, 0xff,
-	0xbb, 0x38, 0x99, 0x71, 0x73, 0x02, 0x00, 0x00,
+	// 354 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0x74, 0x91, 0xcd, 0x4e, 0xeb, 0x30,
+	0x10, 0x85, 0xaf, 0x93, 0x36, 0xf7, 0x66, 0x7a, 0x81, 0xd6, 0x42, 0xc5, 0x0b, 0x16, 0x51, 0xc4,
+	0x22, 0x62, 0x51, 0xa1, 0x56, 0x42, 0x62, 0x85, 0x28, 0x42, 0x62, 0x4b, 0x78, 0x82, 0xfc, 0x98,
+	0xd6, 0xa8, 0x8e, 0xad, 0xd8, 0xad, 0xd4, 0x87, 0xe3, 0x95, 0x78, 0x06, 0x14, 0xdb, 0x4d, 0xfa,
+	0x23, 0x56, 0x71, 0xbe, 0x39, 0x67, 0x46, 0x67, 0x06, 0x40, 0x69, 0xae, 0x27, 0xb2, 0x16, 0x5a,
+	0xe0, 0xbe, 0xf9, 0xc4, 0x5f, 0x08, 0xc2, 0x77, 0x9d, 0x69, 0xca, 0x69, 0xa5, 0xf1, 0x39, 0x78,
+	0xac, 0x24, 0x28, 0x42, 0x49, 0x98, 0x7a, 0xac, 0xc4, 0xd7, 0x10, 0xca, 0x75, 0xbe, 0x62, 0x6a,
+	0x49, 0x6b, 0xe2, 0x19, 0xdc, 0x81, 0xa6, 0x5a, 0x65, 0x9c, 0x2a, 0x99, 0x15, 0x94, 0xf8, 0xb6,
+	0xda, 0x02, 0x9c, 0x40, 0x2f, 0x17, 0xe5, 0x96, 0xf4, 0x22, 0x94, 0x0c, 0xa6, 0x97, 0x76, 0xec,
+	0xa4, 0x9d, 0x35, 0x17, 0xe5, 0x36, 0x35, 0x8a, 0xa6, 0x8f, 0x66, 0x9c, 0x2a, 0x9d, 0x71, 0x49,
+	0xfa, 0x11, 0x4a, 0xfc, 0xb4, 0x03, 0x4d, 0x55, 0xb1, 0x45, 0x95, 0xe9, 0x75, 0x4d, 0x49, 0x10,
+	0xa1, 0xe4, 0x7f, 0xda, 0x81, 0xf8, 0x1b, 0xc1, 0xd9, 0x41, 0x4f, 0x7c, 0x07, 0x81, 0x62, 0x5c,
+	0xae, 0xa8, 0xc9, 0x31, 0x98, 0x8e, 0x77, 0x93, 0x0d, 0x6c, 0xb5, 0xaf, 0x7f, 0x52, 0xa7, 0xc3,
+	0xf7, 0xf0, 0xaf, 0x10, 0x5c, 0x8a, 0x75, 0x55, 0x9a, 0x90, 0x83, 0x29, 0x71, 0x9e, 0x67, 0x87,
+	0xf7, 0x5d, 0xad, 0xb6, 0xf1, 0xd1, 0x6a, 0x43, 0x57, 0x42, 0xda, 0xf8, 0x9d, 0xef, 0xc5, 0xe1,
+	0x03, 0xdf, 0x4e, 0x8b, 0x67, 0xf0, 0x37, 0xab, 0x8b, 0x25, 0xdb, 0x50, 0xb7, 0x9c, 0x2b, 0x67,
+	0x7b, 0xb2, 0x74, 0xdf, 0xb5, 0x53, 0xce, 0x03, 0xbb, 0xce, 0xf8, 0x0d, 0x2e, 0x8e, 0x92, 0xe0,
+	0x31, 0x04, 0x22, 0xff, 0xa4, 0x85, 0x76, 0x97, 0x73, 0x7f, 0x18, 0x43, 0xaf, 0xa6, 0x1f, 0x8a,
+	0x78, 0x91, 0x9f, 0x84, 0xa9, 0x79, 0x37, 0x4c, 0x67, 0x0b, 0x45, 0x7c, 0xcb, 0x9a, 0x77, 0xfc,
+	0x08, 0xa3, 0x93, 0xa0, 0xf8, 0xd6, 0x9d, 0x0f, 0x45, 0xfe, 0xef, 0x4b, 0xb4, 0x07, 0x8c, 0x1f,
+	0x60, 0x74, 0x92, 0x18, 0xdf, 0x1c, 0x34, 0x18, 0x1e, 0xdf, 0xdf, 0x59, 0x31, 0x0c, 0x8f, 0x53,
+	0xe7, 0x81, 0x91, 0xce, 0x7e, 0x02, 0x00, 0x00, 0xff, 0xff, 0xb6, 0x29, 0x78, 0x78, 0xaf, 0x02,
+	0x00, 0x00,
 }

--- a/proto/stmt.proto
+++ b/proto/stmt.proto
@@ -5,16 +5,18 @@ message Statement {
   string id = 1;
   string publisher = 2;
   string namespace = 3;
-  
-  oneof body {
-    SimpleStatement simple = 4;
-    CompoundStatement compound = 5;
-    EnvelopeStatement envelope = 6;
-    ArchiveStatement archive = 7;
-  }
+  StatementBody body = 4;
+  int64 timestamp = 5;
+  bytes signature = 6;
+}
 
-  int64 timestamp = 8;
-  bytes signature = 9;
+message StatementBody {
+  oneof body {
+    SimpleStatement simple = 1;
+    CompoundStatement compound = 2;
+    EnvelopeStatement envelope = 3;
+    ArchiveStatement archive = 4;
+  }
 }
 
 message SimpleStatement {


### PR DESCRIPTION
Implements the remote query protocol, with associated REST api endpoint.
Closes #22 

Notes:
- There is an ABI change in stmt.proto: StatementBody is now a first class type to allow query results
- Remote errors in the query are not propagated in the stream, just logged; perhaps we need to change the query stream protocol to emit error objects in the stream (applies to StatementDb.QueryStream as well)

Example:
```
$ curl http://127.0.0.1:9004/id
Qme1ypbSE8vvuSSeZ5YWTRDDbULUjuTeNJ6QCyijxdmaJt
$ curl -H "Content-Type: application/text" -d 'SELECT COUNT(id) FROM *' http://127.0.0.1:9004/query
0
$ curl -H "Content-Type: application/text" -d 'SELECT COUNT(id) FROM *' http://127.0.0.1:9004/query/QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK
1000
$ curl -H "Content-Type: application/text" -d 'SELECT * FROM * LIMIT 5' http://127.0.0.1:9004/query/QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK
{"id":"QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK:1475492974:0","publisher":"QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK","namespace":"a.b.c","body":{"Body":{"Simple":{"object":"QmABC","refs":["abc"],"tags":["test"]}}},"timestamp":1475492974}
{"id":"QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK:1475492974:1","publisher":"QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK","namespace":"a.b.c","body":{"Body":{"Simple":{"object":"QmABC","refs":["abc"],"tags":["test"]}}},"timestamp":1475492974}
{"id":"QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK:1475492974:2","publisher":"QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK","namespace":"a.b.c","body":{"Body":{"Simple":{"object":"QmABC","refs":["abc"],"tags":["test"]}}},"timestamp":1475492974}
{"id":"QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK:1475492974:3","publisher":"QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK","namespace":"a.b.c","body":{"Body":{"Simple":{"object":"QmABC","refs":["abc"],"tags":["test"]}}},"timestamp":1475492974}
{"id":"QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK:1475492974:4","publisher":"QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK","namespace":"a.b.c","body":{"Body":{"Simple":{"object":"QmABC","refs":["abc"],"tags":["test"]}}},"timestamp":1475492974}
```
