### PR TITLE
Remote merges

### DIFF
--- a/mc/query/query.go
+++ b/mc/query/query.go
@@ -19,6 +19,18 @@ func (q *Query) WithLimit(limit int) *Query {
 	return &Query{q.Op, q.namespace, q.selector, q.criteria, limit}
 }
 
+func (q *Query) IsSimpleSelect(sel string) bool {
+	if q.Op != OpSelect {
+		return false
+	}
+
+	ssel, ok := q.selector.(SimpleSelector)
+	if ok {
+		return sel == string(ssel)
+	}
+	return false
+}
+
 type QuerySelector interface {
 	SelectorType() string
 }

--- a/mcnode/db.go
+++ b/mcnode/db.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	ggproto "github.com/gogo/protobuf/proto"
-	_ "github.com/mattn/go-sqlite3"
+	sqlite3 "github.com/mattn/go-sqlite3"
 	mcq "github.com/mediachain/concat/mc/query"
 	pb "github.com/mediachain/concat/proto"
 	"log"
@@ -324,4 +324,16 @@ func (sdb *SQLiteDB) configPool() {
 	// disable connection pooling as lock contention totally kills
 	// concurrent write performance
 	sdb.db.SetMaxOpenConns(1)
+}
+
+func (sdb *SQLiteDB) Merge(stmt *pb.Statement) (bool, error) {
+	err := sdb.Put(stmt)
+	switch {
+	case err == nil:
+		return true, nil
+	case err == sqlite3.ErrConstraint:
+		return false, nil
+	default:
+		return false, err
+	}
 }

--- a/mcnode/db.go
+++ b/mcnode/db.go
@@ -328,12 +328,12 @@ func (sdb *SQLiteDB) configPool() {
 
 func (sdb *SQLiteDB) Merge(stmt *pb.Statement) (bool, error) {
 	err := sdb.Put(stmt)
-	switch {
-	case err == nil:
-		return true, nil
-	case err == sqlite3.ErrConstraint:
-		return false, nil
-	default:
+	if err != nil {
+		xerr, ok := err.(sqlite3.Error)
+		if ok && xerr.ExtendedCode == sqlite3.ErrConstraintPrimaryKey {
+			return false, nil
+		}
 		return false, err
 	}
+	return true, nil
 }

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -54,6 +54,7 @@ func main() {
 	router.HandleFunc("/stmt/{statementId}", node.httpStatement)
 	router.HandleFunc("/query", node.httpQuery)
 	router.HandleFunc("/query/{peerId}", node.httpRemoteQuery)
+	router.HandleFunc("/merge/{peerId}", node.httpMerge)
 	router.HandleFunc("/delete", node.httpDelete)
 	router.HandleFunc("/status", node.httpStatus)
 	router.HandleFunc("/status/{state}", node.httpStatusSet)

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -35,6 +35,7 @@ type StatementDB interface {
 	Query(*mcq.Query) ([]interface{}, error)
 	QueryStream(context.Context, *mcq.Query) (<-chan interface{}, error)
 	QueryOne(*mcq.Query) (interface{}, error)
+	Merge(*pb.Statement) (bool, error)
 	Delete(*mcq.Query) (int, error)
 	Close() error
 }
@@ -54,6 +55,7 @@ var (
 	BadState         = errors.New("Unrecognized state")
 	BadMethod        = errors.New("Unsupported method")
 	BadNamespace     = errors.New("Illegal namespace")
+	BadResult        = errors.New("Bad result set")
 	NoResult         = errors.New("Empty result set")
 )
 

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -445,3 +445,28 @@ func (node *Node) doRemoteQueryStream(ctx context.Context, s p2p_net.Stream, ch 
 		res.Reset()
 	}
 }
+
+func (node *Node) doMerge(ctx context.Context, pid p2p_peer.ID, q string) (count int, err error) {
+	ch, err := node.doRemoteQuery(ctx, pid, q)
+	if err != nil {
+		return 0, err
+	}
+
+	for val := range ch {
+		switch val := val.(type) {
+		case *pb.Statement:
+			ins, err := node.db.Merge(val)
+			if err != nil {
+				return count, err
+			}
+			if ins {
+				count += 1
+			}
+
+		default:
+			return count, BadResult
+		}
+	}
+
+	return count, nil
+}

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -455,6 +455,7 @@ func (node *Node) doMerge(ctx context.Context, pid p2p_peer.ID, q string) (count
 	for val := range ch {
 		switch val := val.(type) {
 		case *pb.Statement:
+			// TODO statement signature verification
 			ins, err := node.db.Merge(val)
 			if err != nil {
 				return count, err


### PR DESCRIPTION
Adds support for merging remote datasets, by virtue of a statement select query, exposed through the `/merge` endpoint.
Closes #25 

Example:
```
$ curl -H "Content-Type: application/text" -d 'SELECT COUNT(id) FROM *' http://127.0.0.1:9004/query
0
$ curl -H "Content-Type: application/text" -d 'SELECT * FROM * LIMIT 5' http://127.0.0.1:9004/merge/QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK
5
$ curl -H "Content-Type: application/text" -d 'SELECT * FROM * LIMIT 10' http://127.0.0.1:9004/merge/QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK
5
$ curl -H "Content-Type: application/text" -d 'SELECT * FROM * LIMIT 11' http://127.0.0.1:9004/merge/QmWwnVop4hHB3K6z2vuUgU9rh5VrDwMnwuiP9LZew7NzUK
1
$ curl -H "Content-Type: application/text" -d 'SELECT COUNT(id) FROM *' http://127.0.0.1:9004/query
11
```