### PR TITLE
Add index for namespaces in the db

### DIFF
--- a/mcnode/db.go
+++ b/mcnode/db.go
@@ -260,6 +260,11 @@ func (sdb *SQLDB) createTables() error {
 	}
 
 	_, err = sdb.db.Exec("CREATE UNIQUE INDEX EnvelopeId ON Envelope (id)")
+	if err != nil {
+		return err
+	}
+
+	_, err = sdb.db.Exec("CREATE INDEX EnvelopeNS ON Envelope (namespace)")
 	return err
 }
 


### PR DESCRIPTION
It's the one thing we really want to index I think, so this creates an index when creating the database.
You'll want to rebuild your db; either wipe it or manually open it with sqlite and create the index.