### PR TITLE
Public Network Connectivity

### DIFF
--- a/mc/util.go
+++ b/mc/util.go
@@ -79,3 +79,30 @@ func NewHost(id PeerIdentity, laddr multiaddr.Multiaddr, opts ...interface{}) (p
 
 	return p2p_bhost.New(netw, opts...), nil
 }
+
+// multiaddr juggling
+func IsLocalhostAddr(addr multiaddr.Multiaddr) bool {
+	return false
+}
+
+func IsLinkLocalAddr(addr multiaddr.Multiaddr) bool {
+	return false
+}
+
+func IsPrivateAddr(addr multiaddr.Multiaddr) bool {
+	return false
+}
+
+func IsPublicAddr(addr multiaddr.Multiaddr) bool {
+	return false
+}
+
+func FilterAddrs(addrs []multiaddr.Multiaddr, predf func(multiaddr.Multiaddr) bool) []multiaddr.Multiaddr {
+	res := make([]multiaddr.Multiaddr, 0, len(addrs))
+	for _, addr := range addrs {
+		if predf(addr) {
+			res = append(res, addr)
+		}
+	}
+	return res
+}

--- a/mc/util.go
+++ b/mc/util.go
@@ -59,14 +59,17 @@ func ParseHandleId(str string) (empty p2p_pstore.PeerInfo, err error) {
 	return p2p_pstore.PeerInfo{ID: pid}, nil
 }
 
-func NewHost(id PeerIdentity, addrs ...multiaddr.Multiaddr) (p2p_host.Host, error) {
+// re-export this option to avoid basic host interface leakage
+const NATPortMap = p2p_bhost.NATPortMap
+
+func NewHost(id PeerIdentity, laddr multiaddr.Multiaddr, opts ...interface{}) (p2p_host.Host, error) {
 	pstore := p2p_pstore.NewPeerstore()
 	pstore.AddPrivKey(id.ID, id.PrivKey)
 	pstore.AddPubKey(id.ID, id.PrivKey.GetPublic())
 
 	netw, err := p2p_swarm.NewNetwork(
 		context.Background(),
-		addrs,
+		[]multiaddr.Multiaddr{laddr},
 		id.ID,
 		pstore,
 		p2p_metrics.NewBandwidthCounter())
@@ -74,5 +77,5 @@ func NewHost(id PeerIdentity, addrs ...multiaddr.Multiaddr) (p2p_host.Host, erro
 		return nil, err
 	}
 
-	return p2p_bhost.New(netw), nil
+	return p2p_bhost.New(netw, opts...), nil
 }

--- a/mc/util.go
+++ b/mc/util.go
@@ -81,20 +81,42 @@ func NewHost(id PeerIdentity, laddr multiaddr.Multiaddr, opts ...interface{}) (p
 }
 
 // multiaddr juggling
-func IsLocalhostAddr(addr multiaddr.Multiaddr) bool {
+func isAddrSubnet(addr multiaddr.Multiaddr, prefix []string) bool {
+	ip, err := addr.ValueForProtocol(multiaddr.P_IP4)
+	if err != nil {
+		return false
+	}
+
+	for _, pre := range prefix {
+		if strings.HasPrefix(ip, pre) {
+			return true
+		}
+	}
+
 	return false
+}
+
+var (
+	localhostSubnet = []string{"127."}
+	linkLocalSubnet = []string{"169.254."}
+	privateSubnet   = []string{"10.", "172.16.", "192.168."}
+	internalSubnet  = []string{"127.", "169.254.", "10.", "172.16.", "192.168."}
+)
+
+func IsLocalhostAddr(addr multiaddr.Multiaddr) bool {
+	return isAddrSubnet(addr, localhostSubnet)
 }
 
 func IsLinkLocalAddr(addr multiaddr.Multiaddr) bool {
-	return false
+	return isAddrSubnet(addr, linkLocalSubnet)
 }
 
 func IsPrivateAddr(addr multiaddr.Multiaddr) bool {
-	return false
+	return isAddrSubnet(addr, privateSubnet)
 }
 
 func IsPublicAddr(addr multiaddr.Multiaddr) bool {
-	return false
+	return !isAddrSubnet(addr, internalSubnet)
 }
 
 func FilterAddrs(addrs []multiaddr.Multiaddr, predf func(multiaddr.Multiaddr) bool) []multiaddr.Multiaddr {

--- a/mc/util.go
+++ b/mc/util.go
@@ -97,10 +97,11 @@ func isAddrSubnet(addr multiaddr.Multiaddr, prefix []string) bool {
 }
 
 var (
-	localhostSubnet = []string{"127."}
-	linkLocalSubnet = []string{"169.254."}
-	privateSubnet   = []string{"10.", "172.16.", "192.168."}
-	internalSubnet  = []string{"127.", "169.254.", "10.", "172.16.", "192.168."}
+	localhostSubnet  = []string{"127."}
+	linkLocalSubnet  = []string{"169.254."}
+	privateSubnet    = []string{"10.", "172.16.", "192.168."}
+	unroutableSubnet = []string{"0.", "127.", "169.254."}
+	internalSubnet   = []string{"0.", "127.", "169.254.", "10.", "172.16.", "192.168."}
 )
 
 func IsLocalhostAddr(addr multiaddr.Multiaddr) bool {
@@ -113,6 +114,10 @@ func IsLinkLocalAddr(addr multiaddr.Multiaddr) bool {
 
 func IsPrivateAddr(addr multiaddr.Multiaddr) bool {
 	return isAddrSubnet(addr, privateSubnet)
+}
+
+func IsRoutableAddr(addr multiaddr.Multiaddr) bool {
+	return !isAddrSubnet(addr, unroutableSubnet)
 }
 
 func IsPublicAddr(addr multiaddr.Multiaddr) bool {

--- a/mcdir/main.go
+++ b/mcdir/main.go
@@ -158,7 +158,9 @@ func main() {
 	host.SetStreamHandler("/mediachain/dir/list", dir.listHandler)
 
 	for _, addr := range host.Addrs() {
-		log.Printf("I am %s/%s", addr, id.Pretty())
+		if !mc.IsLinkLocalAddr(addr) {
+			log.Printf("I am %s/%s", addr, id.Pretty())
+		}
 	}
 	select {}
 }

--- a/mcdir/main.go
+++ b/mcdir/main.go
@@ -102,7 +102,8 @@ func (dir *Directory) lookupHandler(s p2p_net.Stream) {
 }
 
 func (dir *Directory) listHandler(s p2p_net.Stream) {
-
+	// Implement Me!
+	s.Close()
 }
 
 func (dir *Directory) registerPeer(info p2p_pstore.PeerInfo) {
@@ -141,7 +142,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	addr, err := mc.ParseAddress(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", *port))
+	addr, err := mc.ParseAddress(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", *port))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -156,6 +157,13 @@ func main() {
 	host.SetStreamHandler("/mediachain/dir/lookup", dir.lookupHandler)
 	host.SetStreamHandler("/mediachain/dir/list", dir.listHandler)
 
-	log.Printf("I am %s/%s", addr, id.Pretty())
+	addrs, err := host.Network().InterfaceListenAddresses()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, addr := range addrs {
+		log.Printf("I am %s/%s", addr, id.Pretty())
+	}
 	select {}
 }

--- a/mcdir/main.go
+++ b/mcdir/main.go
@@ -157,12 +157,7 @@ func main() {
 	host.SetStreamHandler("/mediachain/dir/lookup", dir.lookupHandler)
 	host.SetStreamHandler("/mediachain/dir/list", dir.listHandler)
 
-	addrs, err := host.Network().InterfaceListenAddresses()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	for _, addr := range addrs {
+	for _, addr := range host.Addrs() {
 		log.Printf("I am %s/%s", addr, id.Pretty())
 	}
 	select {}

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -422,12 +422,7 @@ func (node *Node) httpConfigNAT(w http.ResponseWriter, r *http.Request) {
 }
 
 func (node *Node) httpConfigNATGet(w http.ResponseWriter, r *http.Request) {
-	switch node.natCfg.opt {
-	case NATConfigManual:
-		fmt.Fprintln(w, node.natCfg.addr.String())
-	default:
-		fmt.Fprintln(w, natConfigString[node.natCfg.opt])
-	}
+	fmt.Fprintln(w, node.natCfg.String())
 }
 
 func (node *Node) httpConfigNATSet(w http.ResponseWriter, r *http.Request) {
@@ -438,20 +433,12 @@ func (node *Node) httpConfigNATSet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	opt := strings.TrimSpace(string(body))
-	switch opt {
-	case "none":
-		node.natCfg.opt = NATConfigNone
-	case "auto":
-		node.natCfg.opt = NATConfigAuto
-	default:
-		addr, err := mc.ParseAddress(opt)
-		if err != nil {
-			apiError(w, http.StatusBadRequest, err)
-			return
-		}
-		node.natCfg.opt = NATConfigManual
-		node.natCfg.addr = addr
+	cfg, err := NATConfigFromString(opt)
+	if err != nil {
+		apiError(w, http.StatusBadRequest, err)
+		return
 	}
 
+	node.natCfg = cfg
 	fmt.Fprintln(w, "OK")
 }

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -411,6 +411,13 @@ func (node *Node) httpConfigDirSet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	node.dir = &pinfo
+
+	err = node.saveConfig()
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, err)
+		return
+	}
+
 	fmt.Fprintln(w, "OK")
 }
 
@@ -440,5 +447,12 @@ func (node *Node) httpConfigNATSet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	node.natCfg = cfg
+
+	err = node.saveConfig()
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, err)
+		return
+	}
+
 	fmt.Fprintln(w, "OK")
 }

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -365,31 +365,40 @@ func (node *Node) httpStatusSet(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, statusString[node.status])
 }
 
-// GET  /config/dir
-// POST /config/dir
-// retrieve/set the configured directory
-func (node *Node) httpConfigDir(w http.ResponseWriter, r *http.Request) {
+// config api
+func apiConfigMethod(w http.ResponseWriter, r *http.Request, getf, setf http.HandlerFunc) {
 	switch r.Method {
 	case http.MethodHead:
 		return
 	case http.MethodGet:
-		if node.dir != nil {
-			fmt.Fprintln(w, mc.FormatHandle(*node.dir))
-		} else {
-			fmt.Fprintln(w, "nil")
-		}
+		getf(w, r)
 	case http.MethodPost:
-		node.httpConfigDirSet(w, r)
+		setf(w, r)
 
 	default:
 		apiError(w, http.StatusBadRequest, BadMethod)
 	}
 }
 
+// GET  /config/dir
+// POST /config/dir
+// retrieve/set the configured directory
+func (node *Node) httpConfigDir(w http.ResponseWriter, r *http.Request) {
+	apiConfigMethod(w, r, node.httpConfigDirGet, node.httpConfigDirSet)
+}
+
+func (node *Node) httpConfigDirGet(w http.ResponseWriter, r *http.Request) {
+	if node.dir != nil {
+		fmt.Fprintln(w, mc.FormatHandle(*node.dir))
+	} else {
+		fmt.Fprintln(w, "nil")
+	}
+}
+
 func (node *Node) httpConfigDirSet(w http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		log.Printf("http/query: Error reading request body: %s", err.Error())
+		log.Printf("http/config/dir: Error reading request body: %s", err.Error())
 		return
 	}
 
@@ -402,5 +411,47 @@ func (node *Node) httpConfigDirSet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	node.dir = &pinfo
+	fmt.Fprintln(w, "OK")
+}
+
+// GET  /config/nat
+// POST /config/nat
+// retrieve/set the NAT configuration
+func (node *Node) httpConfigNAT(w http.ResponseWriter, r *http.Request) {
+	apiConfigMethod(w, r, node.httpConfigNATGet, node.httpConfigNATSet)
+}
+
+func (node *Node) httpConfigNATGet(w http.ResponseWriter, r *http.Request) {
+	switch node.natCfg.opt {
+	case NATConfigManual:
+		fmt.Fprintln(w, node.natCfg.addr.String())
+	default:
+		fmt.Fprintln(w, natConfigString[node.natCfg.opt])
+	}
+}
+
+func (node *Node) httpConfigNATSet(w http.ResponseWriter, r *http.Request) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("http/config/nat: Error reading request body: %s", err.Error())
+		return
+	}
+
+	opt := strings.TrimSpace(string(body))
+	switch opt {
+	case "none":
+		node.natCfg.opt = NATConfigNone
+	case "auto":
+		node.natCfg.opt = NATConfigAuto
+	default:
+		addr, err := mc.ParseAddress(opt)
+		if err != nil {
+			apiError(w, http.StatusBadRequest, err)
+			return
+		}
+		node.natCfg.opt = NATConfigManual
+		node.natCfg.addr = addr
+	}
+
 	fmt.Fprintln(w, "OK")
 }

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -44,6 +44,11 @@ func main() {
 
 	node := &Node{PeerIdentity: id, publisher: pubid, home: *home, laddr: addr}
 
+	err = node.loadConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	err = node.loadDB()
 	if err != nil {
 		log.Fatal(err)

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -64,6 +64,7 @@ func main() {
 	router.HandleFunc("/status", node.httpStatus)
 	router.HandleFunc("/status/{state}", node.httpStatusSet)
 	router.HandleFunc("/config/dir", node.httpConfigDir)
+	router.HandleFunc("/config/nat", node.httpConfigNAT)
 
 	log.Printf("Serving client interface at %s", haddr)
 	err = http.ListenAndServe(haddr, router)

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -22,7 +22,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	addr, err := mc.ParseAddress(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", *pport))
+	addr, err := mc.ParseAddress(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", *pport))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -25,6 +25,7 @@ type Node struct {
 	netCtx    context.Context
 	netCancel context.CancelFunc
 	dir       *p2p_pstore.PeerInfo
+	natCfg    NATConfig
 	home      string
 	db        StatementDB
 	mx        sync.Mutex
@@ -51,6 +52,17 @@ const (
 )
 
 var statusString = []string{"offline", "online", "public"}
+
+type NATConfig struct {
+	opt  int
+	addr multiaddr.Multiaddr // public address when option = NATConfigManual
+}
+
+const (
+	NATConfigNone = iota
+	NATConfigAuto
+	NATConfigManual
+)
 
 var (
 	UnknownStatement = errors.New("Unknown statement")

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -45,6 +45,18 @@ type StatementDB interface {
 	Close() error
 }
 
+var (
+	UnknownStatement = errors.New("Unknown statement")
+	BadStatementBody = errors.New("Unrecognized statement body")
+	BadQuery         = errors.New("Unexpected query")
+	BadState         = errors.New("Unrecognized state")
+	BadMethod        = errors.New("Unsupported method")
+	BadNamespace     = errors.New("Illegal namespace")
+	BadResult        = errors.New("Bad result set")
+	BadStatement     = errors.New("Bad statement; verification failed")
+	NoResult         = errors.New("Empty result set")
+)
+
 const (
 	StatusOffline = iota
 	StatusOnline
@@ -66,17 +78,33 @@ const (
 
 var natConfigString = []string{"none", "auto", "manual"}
 
-var (
-	UnknownStatement = errors.New("Unknown statement")
-	BadStatementBody = errors.New("Unrecognized statement body")
-	BadQuery         = errors.New("Unexpected query")
-	BadState         = errors.New("Unrecognized state")
-	BadMethod        = errors.New("Unsupported method")
-	BadNamespace     = errors.New("Illegal namespace")
-	BadResult        = errors.New("Bad result set")
-	BadStatement     = errors.New("Bad statement; verification failed")
-	NoResult         = errors.New("Empty result set")
-)
+func (cfg NATConfig) String() string {
+	switch cfg.opt {
+	case NATConfigManual:
+		return cfg.addr.String()
+	default:
+		return natConfigString[cfg.opt]
+	}
+}
+
+func NATConfigFromString(str string) (cfg NATConfig, err error) {
+	switch str {
+	case "none":
+		cfg.opt = NATConfigNone
+		return cfg, nil
+	case "auto":
+		cfg.opt = NATConfigAuto
+		return cfg, nil
+	default:
+		addr, err := mc.ParseAddress(str)
+		if err != nil {
+			return cfg, err
+		}
+		cfg.opt = NATConfigManual
+		cfg.addr = addr
+		return cfg, nil
+	}
+}
 
 type StreamError struct {
 	Err string `json:"error"`

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	ggproto "github.com/gogo/protobuf/proto"
@@ -12,6 +13,9 @@ import (
 	mcq "github.com/mediachain/concat/mc/query"
 	pb "github.com/mediachain/concat/proto"
 	multiaddr "github.com/multiformats/go-multiaddr"
+	"io/ioutil"
+	"os"
+	"path"
 	"sync"
 	"time"
 )
@@ -249,4 +253,60 @@ func (node *Node) verifyStatementSig(stmt *pb.Statement, pubk p2p_crypto.PubKey)
 func (node *Node) loadDB() error {
 	node.db = &SQLiteDB{}
 	return node.db.Open(node.home)
+}
+
+// persistent configuration
+type NodeConfig struct {
+	NAT string `json:"nat,omitempty"`
+	Dir string `json:"dir,omitempty"`
+}
+
+func (node *Node) saveConfig() error {
+	var cfg NodeConfig
+	cfg.NAT = node.natCfg.String()
+	if node.dir != nil {
+		cfg.Dir = mc.FormatHandle(*node.dir)
+	}
+
+	bytes, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+
+	cfgpath := path.Join(node.home, "config.json")
+	return ioutil.WriteFile(cfgpath, bytes, 0644)
+}
+
+func (node *Node) loadConfig() error {
+	cfgpath := path.Join(node.home, "config.json")
+
+	bytes, err := ioutil.ReadFile(cfgpath)
+	switch {
+	case os.IsNotExist(err):
+		return nil
+	case err != nil:
+		return err
+	}
+
+	var cfg NodeConfig
+	err = json.Unmarshal(bytes, &cfg)
+	if err != nil {
+		return err
+	}
+
+	natCfg, err := NATConfigFromString(cfg.NAT)
+	if err != nil {
+		return err
+	}
+	node.natCfg = natCfg
+
+	if cfg.Dir != "" {
+		pinfo, err := mc.ParseHandle(cfg.Dir)
+		if err != nil {
+			return err
+		}
+		node.dir = &pinfo
+	}
+
+	return nil
 }

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -64,6 +64,8 @@ const (
 	NATConfigManual
 )
 
+var natConfigString = []string{"none", "auto", "manual"}
+
 var (
 	UnknownStatement = errors.New("Unknown statement")
 	BadStatementBody = errors.New("Unrecognized statement body")

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -65,7 +65,12 @@ func (node *Node) goOnline() error {
 }
 
 func (node *Node) _goOnline() error {
-	host, err := mc.NewHost(node.PeerIdentity, node.laddr)
+	var opts []interface{}
+	if node.natCfg.opt == NATConfigAuto {
+		opts = []interface{}{mc.NATPortMap}
+	}
+
+	host, err := mc.NewHost(node.PeerIdentity, node.laddr, opts...)
 	if err != nil {
 		return err
 	}

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -105,7 +105,7 @@ func (node *Node) goPublic() error {
 		fallthrough
 
 	case StatusOnline:
-		go node.registerPeer(node.netCtx, node.laddr)
+		go node.registerPeer(node.netCtx)
 		node.status = StatusPublic
 
 		log.Println("Node is public")
@@ -235,9 +235,9 @@ func (node *Node) queryHandler(s p2p_net.Stream) {
 	}
 }
 
-func (node *Node) registerPeer(ctx context.Context, addrs ...multiaddr.Multiaddr) {
+func (node *Node) registerPeer(ctx context.Context) {
 	for {
-		err := node.registerPeerImpl(ctx, addrs...)
+		err := node.registerPeerImpl(ctx)
 		if err == nil {
 			return
 		}
@@ -254,7 +254,7 @@ func (node *Node) registerPeer(ctx context.Context, addrs ...multiaddr.Multiaddr
 	}
 }
 
-func (node *Node) registerPeerImpl(ctx context.Context, addrs ...multiaddr.Multiaddr) error {
+func (node *Node) registerPeerImpl(ctx context.Context) error {
 	err := node.host.Connect(ctx, *node.dir)
 	if err != nil {
 		log.Printf("Failed to connect to directory: %s", err.Error())
@@ -268,18 +268,27 @@ func (node *Node) registerPeerImpl(ctx context.Context, addrs ...multiaddr.Multi
 	}
 	defer s.Close()
 
-	pinfo := p2p_pstore.PeerInfo{node.ID, addrs}
+	var pinfo = p2p_pstore.PeerInfo{ID: node.ID}
 	var pbpi pb.PeerInfo
-	mc.PBFromPeerInfo(&pbpi, pinfo)
-	msg := pb.RegisterPeer{&pbpi}
 
 	w := ggio.NewDelimitedWriter(s)
 	for {
-		log.Printf("Registering with directory")
-		err = w.WriteMsg(&msg)
-		if err != nil {
-			log.Printf("Failed to register with directory: %s", err.Error())
-			return err
+		addrs := node.publicAddrs()
+
+		if len(addrs) > 0 {
+			log.Printf("Registering with directory")
+
+			pinfo.Addrs = addrs
+			mc.PBFromPeerInfo(&pbpi, pinfo)
+			msg := pb.RegisterPeer{&pbpi}
+
+			err = w.WriteMsg(&msg)
+			if err != nil {
+				log.Printf("Failed to register with directory: %s", err.Error())
+				return err
+			}
+		} else {
+			log.Printf("Skipped directory registration; no public address")
 		}
 
 		select {
@@ -288,6 +297,49 @@ func (node *Node) registerPeerImpl(ctx context.Context, addrs ...multiaddr.Multi
 
 		case <-time.After(5 * time.Minute):
 			continue
+		}
+	}
+}
+
+// The notion of public address is relative to the network location of the directory
+// We want to support directories running on localhost (testing) or in a private network,
+// and on the same time not leak internal addresses in public directory announcements.
+// So, depending on the directory ip address:
+//  If the directory is on the localhost, return the localhost address reported
+//   by the host
+//  If the directory is link local, return the link local address reported
+//   by the host
+//  If the directory is in a private range, filter Addrs reported by the
+//   host, dropping localhost and link local addresses
+//  If the directory is in a public range, then
+//   If the NAT config is manual, return the configured address
+//   If the NAT is auto or none, filter the addresses returned by the host,
+//      and return only public addresses
+func (node *Node) publicAddrs() []multiaddr.Multiaddr {
+	if node.status == StatusOffline || node.dir == nil {
+		return nil
+	}
+
+	dir := node.dir.Addrs[0]
+	switch {
+	case mc.IsLocalhostAddr(dir):
+		return mc.FilterAddrs(node.host.Addrs(), mc.IsLocalhostAddr)
+
+	case mc.IsLinkLocalAddr(dir):
+		return mc.FilterAddrs(node.host.Addrs(), mc.IsLinkLocalAddr)
+
+	case mc.IsPrivateAddr(dir):
+		return mc.FilterAddrs(node.host.Addrs(), func(addr multiaddr.Multiaddr) bool {
+			return !mc.IsLocalhostAddr(addr) && !mc.IsLinkLocalAddr(addr)
+		})
+
+	default:
+		switch node.natCfg.opt {
+		case NATConfigManual:
+			return []multiaddr.Multiaddr{node.natCfg.addr}
+
+		default:
+			return mc.FilterAddrs(node.host.Addrs(), mc.IsPublicAddr)
 		}
 	}
 }

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -277,6 +277,9 @@ func (node *Node) registerPeerImpl(ctx context.Context) error {
 
 		if len(addrs) > 0 {
 			log.Printf("Registering with directory")
+			for _, addr := range addrs {
+				log.Printf("Public address: %s", addr.String())
+			}
 
 			pinfo.Addrs = addrs
 			mc.PBFromPeerInfo(&pbpi, pinfo)

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -310,10 +310,8 @@ func (node *Node) registerPeerImpl(ctx context.Context) error {
 // So, depending on the directory ip address:
 //  If the directory is on the localhost, return the localhost address reported
 //   by the host
-//  If the directory is link local, return the link local address reported
-//   by the host
 //  If the directory is in a private range, filter Addrs reported by the
-//   host, dropping localhost and link local addresses
+//   host, dropping unroutable addresses
 //  If the directory is in a public range, then
 //   If the NAT config is manual, return the configured address
 //   If the NAT is auto or none, filter the addresses returned by the host,
@@ -328,13 +326,8 @@ func (node *Node) publicAddrs() []multiaddr.Multiaddr {
 	case mc.IsLocalhostAddr(dir):
 		return mc.FilterAddrs(node.host.Addrs(), mc.IsLocalhostAddr)
 
-	case mc.IsLinkLocalAddr(dir):
-		return mc.FilterAddrs(node.host.Addrs(), mc.IsLinkLocalAddr)
-
 	case mc.IsPrivateAddr(dir):
-		return mc.FilterAddrs(node.host.Addrs(), func(addr multiaddr.Multiaddr) bool {
-			return !mc.IsLocalhostAddr(addr) && !mc.IsLinkLocalAddr(addr)
-		})
+		return mc.FilterAddrs(node.host.Addrs(), mc.IsRoutableAddr)
 
 	default:
 		switch node.natCfg.opt {


### PR DESCRIPTION
Performs the necessary work to support the public Internet.
Closes #11 

Summary:
- mcnode and mcdir now bind to INADDR_ANY
- mcnode allows NAT configuration: 
  - none; default, no NAT
  - auto; use the libp2p NATPortMap service
  - manual; uses a user specified public address
- mcnode is selective in how it reports addresses to the directory:
  - if the directory is on localhost, then it reports its localhost address; supports testing
  - if the directory is on a private network, then it will publish its routable addresses
  - if the directory is on a publicly routable network, then it will only report public addresses (if any)
- mcnode configuration is now persisted to disk.

Tested on laptop and ec2.