### PR TITLE
mcnode: add bind address cli flag for http api

### DIFF
--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -13,6 +13,7 @@ import (
 func main() {
 	pport := flag.Int("l", 9001, "Peer listen port")
 	cport := flag.Int("c", 9002, "Peer control interface port [http]")
+	bindaddr := flag.String("b", "127.0.0.1", "Peer control bind address [http]")
 	home := flag.String("d", "/tmp/mcnode", "Node home")
 	flag.Parse()
 
@@ -56,7 +57,7 @@ func main() {
 
 	log.Println("Node is offline")
 
-	haddr := fmt.Sprintf("127.0.0.1:%d", *cport)
+	haddr := fmt.Sprintf("%s:%d", *bindaddr, *cport)
 	router := mux.NewRouter().StrictSlash(true)
 	router.HandleFunc("/id", node.httpId)
 	router.HandleFunc("/ping/{peerId}", node.httpPing)


### PR DESCRIPTION
I've been working on getting integration tests setup between aleph & concat, by running a concat node in a docker container.  To get it to work, I need to be able to have the HTTP API server listen on an external IP instead of localhost, so this adds a `-b` flag that lets you bind the API server to 0.0.0.0 (or whatever)