### PR TITLE
Datastore and statement metadata

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-gx-go rewrite && go build ./... && gx-go rewrite --undo
+gx-go rewrite && go build -tags=embed ./... && gx-go rewrite --undo

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-gx-go rewrite && go install ./... && gx-go rewrite --undo
+gx-go rewrite && go install -tags=embed ./... && gx-go rewrite --undo

--- a/mc/util.go
+++ b/mc/util.go
@@ -11,10 +11,17 @@ import (
 	p2p_swarm "github.com/libp2p/go-libp2p-swarm"
 	p2p_bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	multiaddr "github.com/multiformats/go-multiaddr"
+	multihash "github.com/multiformats/go-multihash"
 	"log"
 	"net"
 	"strings"
 )
+
+func Hash(data []byte) multihash.Multihash {
+	// this can only fail with an error because of an incorrect hash family
+	mh, _ := multihash.Sum(data, multihash.SHA2_256, -1)
+	return mh
+}
 
 func ParseAddress(str string) (multiaddr.Multiaddr, error) {
 	return multiaddr.NewMultiaddr(str)

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -281,16 +281,21 @@ func (node *Node) httpMerge(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
-	count, err := node.doMerge(ctx, pid, q)
+	count, ocount, err := node.doMerge(ctx, pid, q)
 	if err != nil {
 		apiError(w, http.StatusInternalServerError, err)
 		if count > 0 {
 			fmt.Fprintf(w, "Partial merge: %d statements merged\n", count)
 		}
+		if ocount > 0 {
+			fmt.Fprintf(w, "Partial merge: %d objects merged\n", ocount)
+		}
+
 		return
 	}
 
 	fmt.Fprintln(w, count)
+	fmt.Fprintln(w, ocount)
 }
 
 // POST /delete

--- a/mcnode/db.go
+++ b/mcnode/db.go
@@ -315,8 +315,14 @@ func (sdb *SQLiteDB) Open(home string) error {
 		dbpath = home
 		mktables = true
 	} else {
-		dbpath = path.Join(home, "stmt.db")
-		_, err := os.Stat(dbpath)
+		dbdir := path.Join(home, "stmt")
+		err := os.MkdirAll(dbdir, 0755)
+		if err != nil {
+			return err
+		}
+
+		dbpath = path.Join(dbdir, "stmt.db")
+		_, err = os.Stat(dbpath)
 		switch {
 		case os.IsNotExist(err):
 			mktables = true

--- a/mcnode/ds.go
+++ b/mcnode/ds.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"errors"
+	mc "github.com/mediachain/concat/mc"
 	rocksdb "github.com/tecbot/gorocksdb"
 	"path"
 	"runtime"
@@ -46,21 +46,31 @@ func (ds *RocksDS) Open(home string) error {
 }
 
 func (ds *RocksDS) Put(data []byte) (Key, error) {
-	return nil, errors.New("Implement me!")
+	key := mc.Hash(data)
+	err := ds.db.Put(ds.wo, key[2:], data)
+	return Key(key), err
 }
 
-func (ds *RocksDS) Has(Key) (bool, error) {
-	return false, errors.New("Implement me!")
+func (ds *RocksDS) Has(key Key) (bool, error) {
+	// gorocksdb has no native key check, so we need to do a get
+	// small optimization: use Get instead of GetBytes to avoid the extra copy
+	// to byte slice when the data is present
+	val, err := ds.db.Get(ds.ro, key[2:])
+	if err != nil {
+		return false, err
+	}
+	defer val.Free()
+	return val.Size() > 0, nil
 }
 
-func (ds *RocksDS) Get(Key) ([]byte, error) {
-	return nil, errors.New("Implement me!")
+func (ds *RocksDS) Get(key Key) ([]byte, error) {
+	return ds.db.GetBytes(ds.ro, key[2:])
 }
 
-func (ds *RocksDS) Delete(Key) error {
-	return errors.New("Implement me!")
+func (ds *RocksDS) Delete(key Key) error {
+	return ds.db.Delete(ds.wo, key[2:])
 }
 
-func (ds *RocksDS) Close() error {
-	return errors.New("Implement me!")
+func (ds *RocksDS) Close() {
+	ds.db.Close()
 }

--- a/mcnode/ds.go
+++ b/mcnode/ds.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"errors"
+	rocksdb "github.com/tecbot/gorocksdb"
+	"path"
+	"runtime"
+)
+
+type RocksDS struct {
+	db *rocksdb.DB
+	ro *rocksdb.ReadOptions
+	wo *rocksdb.WriteOptions
+}
+
+func (ds *RocksDS) Open(home string) error {
+	dbpath := path.Join(home, "data")
+	// options
+	opts := rocksdb.NewDefaultOptions()
+	opts.SetCreateIfMissing(true)
+
+	// bloom filter
+	filter := rocksdb.NewBloomFilter(10)
+	bbto := rocksdb.NewDefaultBlockBasedTableOptions()
+	bbto.SetFilterPolicy(filter)
+	opts.SetBlockBasedTableFactory(bbto)
+
+	// paraellism tuning
+	opts.IncreaseParallelism(runtime.NumCPU())
+
+	// We are not going to be iterating over the datastore as far as I can tell
+	// so we can use this option.
+	// I don't know if 16MB is a good value for the block cache size
+	opts.OptimizeForPointLookup(16)
+
+	db, err := rocksdb.OpenDb(opts, dbpath)
+	if err != nil {
+		return err
+	}
+
+	ds.db = db
+	ds.ro = rocksdb.NewDefaultReadOptions()
+	ds.wo = rocksdb.NewDefaultWriteOptions()
+
+	return nil
+}
+
+func (ds *RocksDS) Put(data []byte) (Key, error) {
+	return nil, errors.New("Implement me!")
+}
+
+func (ds *RocksDS) Has(Key) (bool, error) {
+	return false, errors.New("Implement me!")
+}
+
+func (ds *RocksDS) Get(Key) ([]byte, error) {
+	return nil, errors.New("Implement me!")
+}
+
+func (ds *RocksDS) Delete(Key) error {
+	return errors.New("Implement me!")
+}
+
+func (ds *RocksDS) Close() error {
+	return errors.New("Implement me!")
+}

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -49,7 +49,12 @@ func main() {
 		log.Fatal(err)
 	}
 
-	err = node.loadDB()
+	err = node.openDB()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = node.openDS()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -72,6 +72,8 @@ func main() {
 	router.HandleFunc("/query/{peerId}", node.httpRemoteQuery)
 	router.HandleFunc("/merge/{peerId}", node.httpMerge)
 	router.HandleFunc("/delete", node.httpDelete)
+	router.HandleFunc("/data/put", node.httpPutData)
+	router.HandleFunc("/data/get/{objectId}", node.httpGetData)
 	router.HandleFunc("/status", node.httpStatus)
 	router.HandleFunc("/status/{state}", node.httpStatusSet)
 	router.HandleFunc("/config/dir", node.httpConfigDir)

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -58,7 +58,7 @@ type Datastore interface {
 	Has(Key) (bool, error)
 	Get(Key) ([]byte, error)
 	Delete(Key) error
-	Close() error
+	Close()
 }
 
 var (

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -268,8 +268,8 @@ func (node *Node) openDB() error {
 }
 
 func (node *Node) openDS() error {
-	// XXX Implement me!
-	return nil
+	node.ds = &RocksDS{}
+	return node.ds.Open(node.home)
 }
 
 // persistent configuration

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -64,6 +64,7 @@ type Datastore interface {
 
 var (
 	UnknownStatement = errors.New("Unknown statement")
+	UnknownObject    = errors.New("Unknown Object")
 	BadStatementBody = errors.New("Unrecognized statement body")
 	BadQuery         = errors.New("Unexpected query")
 	BadState         = errors.New("Unrecognized state")

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -55,6 +55,7 @@ type Key multihash.Multihash
 type Datastore interface {
 	Open(home string) error
 	Put(data []byte) (Key, error)
+	PutBatch(batch [][]byte) ([]Key, error)
 	Has(Key) (bool, error)
 	Get(Key) ([]byte, error)
 	Delete(Key) error

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -13,6 +13,7 @@ import (
 	mcq "github.com/mediachain/concat/mc/query"
 	pb "github.com/mediachain/concat/proto"
 	multiaddr "github.com/multiformats/go-multiaddr"
+	multihash "github.com/multiformats/go-multihash"
 	"io/ioutil"
 	"os"
 	"path"
@@ -32,6 +33,7 @@ type Node struct {
 	natCfg    NATConfig
 	home      string
 	db        StatementDB
+	ds        Datastore
 	mx        sync.Mutex
 	counter   int
 }
@@ -46,6 +48,16 @@ type StatementDB interface {
 	QueryOne(*mcq.Query) (interface{}, error)
 	Merge(*pb.Statement) (bool, error)
 	Delete(*mcq.Query) (int, error)
+	Close() error
+}
+
+type Key multihash.Multihash
+type Datastore interface {
+	Open(home string) error
+	Put(data []byte) (Key, error)
+	Has(Key) (bool, error)
+	Get(Key) ([]byte, error)
+	Delete(Key) error
 	Close() error
 }
 
@@ -250,9 +262,14 @@ func (node *Node) verifyStatementSig(stmt *pb.Statement, pubk p2p_crypto.PubKey)
 	return pubk.Verify(bytes, sig)
 }
 
-func (node *Node) loadDB() error {
+func (node *Node) openDB() error {
 	node.db = &SQLiteDB{}
 	return node.db.Open(node.home)
+}
+
+func (node *Node) openDS() error {
+	// XXX Implement me!
+	return nil
 }
 
 // persistent configuration

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -73,6 +73,9 @@ var (
 	BadResult        = errors.New("Bad result set")
 	BadStatement     = errors.New("Bad statement; verification failed")
 	NoResult         = errors.New("Empty result set")
+	MissingData      = errors.New("Missing statement metadata")
+	UnexpectedData   = errors.New("Unexpected data object")
+	BadData          = errors.New("Bad data object; hash mismatch")
 )
 
 const (
@@ -224,6 +227,15 @@ func (node *Node) signStatement(stmt *pb.Statement) error {
 
 	stmt.Signature = sig
 	return nil
+}
+
+func (node *Node) checkStatement(stmt *pb.Statement) bool {
+	return stmt.Id != "" &&
+		stmt.Publisher != "" &&
+		stmt.Namespace != "" &&
+		stmt.Timestamp > 0 &&
+		stmt.Body != nil &&
+		stmt.Signature != nil
 }
 
 func (node *Node) verifyStatement(stmt *pb.Statement) (bool, error) {

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -621,7 +621,7 @@ func (node *Node) doMerge(ctx context.Context, pid p2p_peer.ID, q string) (count
 				return count, ocount, err
 			}
 
-			if len(keys) > batch {
+			if len(keys) >= batch {
 				bcount, err := node.doMergeData(s, keys)
 				ocount += bcount
 				if err != nil {

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -157,12 +157,12 @@ func (node *Node) queryHandler(s p2p_net.Stream) {
 	w := ggio.NewDelimitedWriter(s)
 
 	writeError := func(err error) {
-		res.Result = &pb.QueryResult_Error{&pb.QueryResultError{err.Error()}}
+		res.Result = &pb.QueryResult_Error{&pb.StreamError{err.Error()}}
 		w.WriteMsg(&res)
 	}
 
 	writeEnd := func() error {
-		res.Result = &pb.QueryResult_End{&pb.QueryResultEnd{}}
+		res.Result = &pb.QueryResult_End{&pb.StreamEnd{}}
 		return w.WriteMsg(&res)
 	}
 

--- a/proto/dir.pb.go
+++ b/proto/dir.pb.go
@@ -17,16 +17,19 @@ It has these top-level messages:
 	LookupPeerResponse
 	ListPeersRequest
 	ListPeersResponse
+	StreamEnd
+	StreamError
 	Ping
 	Pong
 	QueryRequest
 	QueryResult
-	QueryResultEnd
-	QueryResultError
 	QueryResultValue
 	SimpleValue
 	CompoundValue
 	KeyValuePair
+	DataRequest
+	DataResult
+	DataObject
 	Statement
 	StatementBody
 	SimpleStatement

--- a/proto/node.pb.go
+++ b/proto/node.pb.go
@@ -13,14 +13,33 @@ var _ = proto1.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-// node/ping
+// end of result stream marker
+type StreamEnd struct {
+}
+
+func (m *StreamEnd) Reset()                    { *m = StreamEnd{} }
+func (m *StreamEnd) String() string            { return proto1.CompactTextString(m) }
+func (*StreamEnd) ProtoMessage()               {}
+func (*StreamEnd) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{0} }
+
+// stream errors
+type StreamError struct {
+	Error string `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"`
+}
+
+func (m *StreamError) Reset()                    { *m = StreamError{} }
+func (m *StreamError) String() string            { return proto1.CompactTextString(m) }
+func (*StreamError) ProtoMessage()               {}
+func (*StreamError) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{1} }
+
+// /mediachain/node/ping
 type Ping struct {
 }
 
 func (m *Ping) Reset()                    { *m = Ping{} }
 func (m *Ping) String() string            { return proto1.CompactTextString(m) }
 func (*Ping) ProtoMessage()               {}
-func (*Ping) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{0} }
+func (*Ping) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{2} }
 
 type Pong struct {
 }
@@ -28,9 +47,9 @@ type Pong struct {
 func (m *Pong) Reset()                    { *m = Pong{} }
 func (m *Pong) String() string            { return proto1.CompactTextString(m) }
 func (*Pong) ProtoMessage()               {}
-func (*Pong) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{1} }
+func (*Pong) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{3} }
 
-// node/query
+// /mediachain/node/query
 type QueryRequest struct {
 	Query string `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
 }
@@ -38,7 +57,7 @@ type QueryRequest struct {
 func (m *QueryRequest) Reset()                    { *m = QueryRequest{} }
 func (m *QueryRequest) String() string            { return proto1.CompactTextString(m) }
 func (*QueryRequest) ProtoMessage()               {}
-func (*QueryRequest) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{2} }
+func (*QueryRequest) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{4} }
 
 type QueryResult struct {
 	// Types that are valid to be assigned to Result:
@@ -51,7 +70,7 @@ type QueryResult struct {
 func (m *QueryResult) Reset()                    { *m = QueryResult{} }
 func (m *QueryResult) String() string            { return proto1.CompactTextString(m) }
 func (*QueryResult) ProtoMessage()               {}
-func (*QueryResult) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{3} }
+func (*QueryResult) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{5} }
 
 type isQueryResult_Result interface {
 	isQueryResult_Result()
@@ -61,10 +80,10 @@ type QueryResult_Value struct {
 	Value *QueryResultValue `protobuf:"bytes,1,opt,name=value,oneof"`
 }
 type QueryResult_End struct {
-	End *QueryResultEnd `protobuf:"bytes,2,opt,name=end,oneof"`
+	End *StreamEnd `protobuf:"bytes,2,opt,name=end,oneof"`
 }
 type QueryResult_Error struct {
-	Error *QueryResultError `protobuf:"bytes,3,opt,name=error,oneof"`
+	Error *StreamError `protobuf:"bytes,3,opt,name=error,oneof"`
 }
 
 func (*QueryResult_Value) isQueryResult_Result() {}
@@ -85,14 +104,14 @@ func (m *QueryResult) GetValue() *QueryResultValue {
 	return nil
 }
 
-func (m *QueryResult) GetEnd() *QueryResultEnd {
+func (m *QueryResult) GetEnd() *StreamEnd {
 	if x, ok := m.GetResult().(*QueryResult_End); ok {
 		return x.End
 	}
 	return nil
 }
 
-func (m *QueryResult) GetError() *QueryResultError {
+func (m *QueryResult) GetError() *StreamError {
 	if x, ok := m.GetResult().(*QueryResult_Error); ok {
 		return x.Error
 	}
@@ -149,7 +168,7 @@ func _QueryResult_OneofUnmarshaler(msg proto1.Message, tag, wire int, b *proto1.
 		if wire != proto1.WireBytes {
 			return true, proto1.ErrInternalBadWireType
 		}
-		msg := new(QueryResultEnd)
+		msg := new(StreamEnd)
 		err := b.DecodeMessage(msg)
 		m.Result = &QueryResult_End{msg}
 		return true, err
@@ -157,7 +176,7 @@ func _QueryResult_OneofUnmarshaler(msg proto1.Message, tag, wire int, b *proto1.
 		if wire != proto1.WireBytes {
 			return true, proto1.ErrInternalBadWireType
 		}
-		msg := new(QueryResultError)
+		msg := new(StreamError)
 		err := b.DecodeMessage(msg)
 		m.Result = &QueryResult_Error{msg}
 		return true, err
@@ -191,23 +210,6 @@ func _QueryResult_OneofSizer(msg proto1.Message) (n int) {
 	}
 	return n
 }
-
-type QueryResultEnd struct {
-}
-
-func (m *QueryResultEnd) Reset()                    { *m = QueryResultEnd{} }
-func (m *QueryResultEnd) String() string            { return proto1.CompactTextString(m) }
-func (*QueryResultEnd) ProtoMessage()               {}
-func (*QueryResultEnd) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{4} }
-
-type QueryResultError struct {
-	Error string `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"`
-}
-
-func (m *QueryResultError) Reset()                    { *m = QueryResultError{} }
-func (m *QueryResultError) String() string            { return proto1.CompactTextString(m) }
-func (*QueryResultError) ProtoMessage()               {}
-func (*QueryResultError) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{5} }
 
 type QueryResultValue struct {
 	// Types that are valid to be assigned to Value:
@@ -537,46 +539,225 @@ func (m *KeyValuePair) GetValue() *SimpleValue {
 	return nil
 }
 
+// /mediachain/node/data
+type DataRequest struct {
+	Keys []string `protobuf:"bytes,1,rep,name=keys" json:"keys,omitempty"`
+}
+
+func (m *DataRequest) Reset()                    { *m = DataRequest{} }
+func (m *DataRequest) String() string            { return proto1.CompactTextString(m) }
+func (*DataRequest) ProtoMessage()               {}
+func (*DataRequest) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{10} }
+
+type DataResult struct {
+	// Types that are valid to be assigned to Result:
+	//	*DataResult_Data
+	//	*DataResult_End
+	//	*DataResult_Error
+	Result isDataResult_Result `protobuf_oneof:"result"`
+}
+
+func (m *DataResult) Reset()                    { *m = DataResult{} }
+func (m *DataResult) String() string            { return proto1.CompactTextString(m) }
+func (*DataResult) ProtoMessage()               {}
+func (*DataResult) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{11} }
+
+type isDataResult_Result interface {
+	isDataResult_Result()
+}
+
+type DataResult_Data struct {
+	Data *DataObject `protobuf:"bytes,1,opt,name=data,oneof"`
+}
+type DataResult_End struct {
+	End *StreamEnd `protobuf:"bytes,2,opt,name=end,oneof"`
+}
+type DataResult_Error struct {
+	Error *StreamError `protobuf:"bytes,3,opt,name=error,oneof"`
+}
+
+func (*DataResult_Data) isDataResult_Result()  {}
+func (*DataResult_End) isDataResult_Result()   {}
+func (*DataResult_Error) isDataResult_Result() {}
+
+func (m *DataResult) GetResult() isDataResult_Result {
+	if m != nil {
+		return m.Result
+	}
+	return nil
+}
+
+func (m *DataResult) GetData() *DataObject {
+	if x, ok := m.GetResult().(*DataResult_Data); ok {
+		return x.Data
+	}
+	return nil
+}
+
+func (m *DataResult) GetEnd() *StreamEnd {
+	if x, ok := m.GetResult().(*DataResult_End); ok {
+		return x.End
+	}
+	return nil
+}
+
+func (m *DataResult) GetError() *StreamError {
+	if x, ok := m.GetResult().(*DataResult_Error); ok {
+		return x.Error
+	}
+	return nil
+}
+
+// XXX_OneofFuncs is for the internal use of the proto package.
+func (*DataResult) XXX_OneofFuncs() (func(msg proto1.Message, b *proto1.Buffer) error, func(msg proto1.Message, tag, wire int, b *proto1.Buffer) (bool, error), func(msg proto1.Message) (n int), []interface{}) {
+	return _DataResult_OneofMarshaler, _DataResult_OneofUnmarshaler, _DataResult_OneofSizer, []interface{}{
+		(*DataResult_Data)(nil),
+		(*DataResult_End)(nil),
+		(*DataResult_Error)(nil),
+	}
+}
+
+func _DataResult_OneofMarshaler(msg proto1.Message, b *proto1.Buffer) error {
+	m := msg.(*DataResult)
+	// result
+	switch x := m.Result.(type) {
+	case *DataResult_Data:
+		_ = b.EncodeVarint(1<<3 | proto1.WireBytes)
+		if err := b.EncodeMessage(x.Data); err != nil {
+			return err
+		}
+	case *DataResult_End:
+		_ = b.EncodeVarint(2<<3 | proto1.WireBytes)
+		if err := b.EncodeMessage(x.End); err != nil {
+			return err
+		}
+	case *DataResult_Error:
+		_ = b.EncodeVarint(3<<3 | proto1.WireBytes)
+		if err := b.EncodeMessage(x.Error); err != nil {
+			return err
+		}
+	case nil:
+	default:
+		return fmt.Errorf("DataResult.Result has unexpected type %T", x)
+	}
+	return nil
+}
+
+func _DataResult_OneofUnmarshaler(msg proto1.Message, tag, wire int, b *proto1.Buffer) (bool, error) {
+	m := msg.(*DataResult)
+	switch tag {
+	case 1: // result.data
+		if wire != proto1.WireBytes {
+			return true, proto1.ErrInternalBadWireType
+		}
+		msg := new(DataObject)
+		err := b.DecodeMessage(msg)
+		m.Result = &DataResult_Data{msg}
+		return true, err
+	case 2: // result.end
+		if wire != proto1.WireBytes {
+			return true, proto1.ErrInternalBadWireType
+		}
+		msg := new(StreamEnd)
+		err := b.DecodeMessage(msg)
+		m.Result = &DataResult_End{msg}
+		return true, err
+	case 3: // result.error
+		if wire != proto1.WireBytes {
+			return true, proto1.ErrInternalBadWireType
+		}
+		msg := new(StreamError)
+		err := b.DecodeMessage(msg)
+		m.Result = &DataResult_Error{msg}
+		return true, err
+	default:
+		return false, nil
+	}
+}
+
+func _DataResult_OneofSizer(msg proto1.Message) (n int) {
+	m := msg.(*DataResult)
+	// result
+	switch x := m.Result.(type) {
+	case *DataResult_Data:
+		s := proto1.Size(x.Data)
+		n += proto1.SizeVarint(1<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(uint64(s))
+		n += s
+	case *DataResult_End:
+		s := proto1.Size(x.End)
+		n += proto1.SizeVarint(2<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(uint64(s))
+		n += s
+	case *DataResult_Error:
+		s := proto1.Size(x.Error)
+		n += proto1.SizeVarint(3<<3 | proto1.WireBytes)
+		n += proto1.SizeVarint(uint64(s))
+		n += s
+	case nil:
+	default:
+		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
+	}
+	return n
+}
+
+type DataObject struct {
+	Key  string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Data []byte `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+}
+
+func (m *DataObject) Reset()                    { *m = DataObject{} }
+func (m *DataObject) String() string            { return proto1.CompactTextString(m) }
+func (*DataObject) ProtoMessage()               {}
+func (*DataObject) Descriptor() ([]byte, []int) { return fileDescriptorNode, []int{12} }
+
 func init() {
+	proto1.RegisterType((*StreamEnd)(nil), "proto.StreamEnd")
+	proto1.RegisterType((*StreamError)(nil), "proto.StreamError")
 	proto1.RegisterType((*Ping)(nil), "proto.Ping")
 	proto1.RegisterType((*Pong)(nil), "proto.Pong")
 	proto1.RegisterType((*QueryRequest)(nil), "proto.QueryRequest")
 	proto1.RegisterType((*QueryResult)(nil), "proto.QueryResult")
-	proto1.RegisterType((*QueryResultEnd)(nil), "proto.QueryResultEnd")
-	proto1.RegisterType((*QueryResultError)(nil), "proto.QueryResultError")
 	proto1.RegisterType((*QueryResultValue)(nil), "proto.QueryResultValue")
 	proto1.RegisterType((*SimpleValue)(nil), "proto.SimpleValue")
 	proto1.RegisterType((*CompoundValue)(nil), "proto.CompoundValue")
 	proto1.RegisterType((*KeyValuePair)(nil), "proto.KeyValuePair")
+	proto1.RegisterType((*DataRequest)(nil), "proto.DataRequest")
+	proto1.RegisterType((*DataResult)(nil), "proto.DataResult")
+	proto1.RegisterType((*DataObject)(nil), "proto.DataObject")
 }
 
 func init() { proto1.RegisterFile("node.proto", fileDescriptorNode) }
 
 var fileDescriptorNode = []byte{
-	// 386 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0x74, 0x92, 0x41, 0x6b, 0xdb, 0x30,
-	0x14, 0xc7, 0xed, 0xd8, 0xf1, 0x92, 0xe7, 0x6c, 0x18, 0x2d, 0x63, 0x66, 0xec, 0x10, 0xc4, 0xd8,
-	0x3c, 0x28, 0x29, 0xa4, 0x97, 0x9e, 0x53, 0x02, 0xa6, 0xbd, 0xa4, 0x2e, 0xf4, 0x9e, 0xd4, 0x22,
-	0x98, 0xc6, 0x52, 0x22, 0xcb, 0x85, 0x1c, 0xfa, 0x6d, 0xfa, 0x11, 0xfa, 0x01, 0xcb, 0x93, 0xa5,
-	0xd4, 0x6e, 0xc9, 0x49, 0xd6, 0xff, 0xfd, 0xf4, 0x7f, 0xff, 0x27, 0x0b, 0x80, 0x8b, 0x9c, 0x4d,
-	0x77, 0x52, 0x28, 0x41, 0xfa, 0x7a, 0xf9, 0x05, 0x95, 0x2a, 0x55, 0x23, 0xd1, 0x00, 0xfc, 0x65,
-	0xc1, 0x37, 0x7a, 0x15, 0x7c, 0x43, 0xff, 0xc0, 0xe8, 0xb6, 0x66, 0xf2, 0x90, 0xb1, 0x7d, 0xcd,
-	0x2a, 0x45, 0xc6, 0xd0, 0xdf, 0xe3, 0x3e, 0x76, 0x27, 0x6e, 0x32, 0xcc, 0x9a, 0x0d, 0x7d, 0x71,
-	0x21, 0x34, 0x58, 0x55, 0x6f, 0x15, 0x39, 0x87, 0xfe, 0xd3, 0x6a, 0x5b, 0x33, 0x4d, 0x85, 0xb3,
-	0x9f, 0x8d, 0xf9, 0xb4, 0x85, 0xdc, 0x63, 0x39, 0x75, 0xb2, 0x86, 0x23, 0xff, 0xc1, 0x63, 0x3c,
-	0x8f, 0x7b, 0x1a, 0xff, 0xf1, 0x19, 0x5f, 0xf0, 0x3c, 0x75, 0x32, 0x64, 0xd0, 0x9b, 0x49, 0x29,
-	0x64, 0xec, 0x9d, 0xf2, 0x5e, 0x60, 0x19, 0xbd, 0x35, 0x37, 0x1f, 0x40, 0x20, 0xb5, 0x4e, 0x23,
-	0xf8, 0xd6, 0xf5, 0xa4, 0x09, 0x44, 0x1f, 0x0f, 0xe2, 0x88, 0x4d, 0x03, 0x33, 0xa2, 0xde, 0xd0,
-	0xe7, 0x0e, 0xa9, 0xe3, 0x93, 0x33, 0x08, 0xaa, 0xa2, 0xdc, 0x6d, 0xed, 0x9c, 0xc4, 0x64, 0xb9,
-	0xd3, 0xa2, 0x1d, 0xd1, 0x30, 0x64, 0x06, 0x83, 0x07, 0x51, 0xee, 0x44, 0x7d, 0x1c, 0x74, 0x6c,
-	0xf8, 0x2b, 0x23, 0xdb, 0x13, 0x47, 0x6e, 0xfe, 0xc5, 0x5c, 0x24, 0x7d, 0x75, 0x21, 0x6c, 0xd9,
-	0x92, 0xdf, 0x30, 0x28, 0x78, 0x13, 0x43, 0x37, 0xf7, 0xf0, 0x98, 0x55, 0x08, 0x85, 0xb0, 0x52,
-	0xb2, 0xe0, 0x9b, 0x06, 0xc0, 0x6e, 0xc3, 0xd4, 0xc9, 0xda, 0x22, 0xf9, 0x0b, 0x3e, 0xfe, 0x77,
-	0x73, 0x8d, 0x91, 0x8d, 0xae, 0x56, 0x8a, 0x95, 0x8c, 0xab, 0xd4, 0xc9, 0x74, 0x1d, 0x63, 0xe3,
-	0x3a, 0x17, 0xf9, 0x21, 0xf6, 0x3b, 0xb1, 0x8f, 0x2c, 0xd6, 0xb0, 0xbf, 0xe5, 0xde, 0x63, 0x5f,
-	0xc2, 0xd7, 0xce, 0x70, 0xe4, 0x1f, 0xf8, 0x6b, 0x74, 0x72, 0x27, 0x5e, 0x12, 0xce, 0xbe, 0x1b,
-	0xa7, 0x1b, 0x76, 0xd0, 0xe5, 0xe5, 0xaa, 0x90, 0x99, 0x06, 0xe8, 0x35, 0x8c, 0xda, 0x2a, 0x89,
-	0xc0, 0x7b, 0x64, 0xf6, 0xd9, 0xe1, 0x27, 0x49, 0xec, 0x23, 0xeb, 0x9d, 0xba, 0x7c, 0xf3, 0xba,
-	0xd6, 0x81, 0xae, 0x5c, 0xbc, 0x05, 0x00, 0x00, 0xff, 0xff, 0x21, 0x5c, 0x63, 0x0f, 0xfc, 0x02,
-	0x00, 0x00,
+	// 451 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0xb4, 0x92, 0xc1, 0x8e, 0xd3, 0x30,
+	0x10, 0x86, 0x9b, 0x4d, 0x5a, 0xda, 0x49, 0x91, 0xca, 0xb0, 0x12, 0x15, 0xe2, 0xb0, 0x98, 0x15,
+	0x5b, 0x21, 0xb4, 0x48, 0xe5, 0xc2, 0xb9, 0x80, 0x54, 0xc1, 0x81, 0x25, 0x48, 0xdc, 0xdd, 0x8d,
+	0x55, 0x85, 0x6d, 0xec, 0xae, 0xe3, 0x20, 0xf5, 0xc0, 0x43, 0x70, 0xe5, 0x39, 0x78, 0x40, 0x34,
+	0x63, 0x3b, 0x6d, 0x11, 0x1c, 0xf7, 0x64, 0x7b, 0xe6, 0x9b, 0xf9, 0xff, 0x4c, 0x06, 0x40, 0x9b,
+	0x52, 0x5d, 0x6e, 0xad, 0x71, 0x06, 0xfb, 0x7c, 0x3c, 0x86, 0xc6, 0xd5, 0xce, 0x87, 0x44, 0x0e,
+	0xa3, 0x2f, 0xce, 0x2a, 0x59, 0xbf, 0xd7, 0xa5, 0x78, 0x06, 0x79, 0x78, 0x58, 0x6b, 0x2c, 0x9e,
+	0x42, 0x5f, 0xd1, 0x65, 0x9a, 0x9c, 0x25, 0xb3, 0x51, 0xe1, 0x1f, 0x62, 0x00, 0xd9, 0x55, 0xa5,
+	0xd7, 0x7c, 0x1a, 0xbd, 0x16, 0xe7, 0x30, 0xfe, 0xdc, 0x2a, 0xbb, 0x2b, 0xd4, 0x6d, 0xab, 0x1a,
+	0x47, 0x55, 0xb7, 0xf4, 0x8e, 0x55, 0xfc, 0x10, 0xbf, 0x12, 0xc8, 0x03, 0xd6, 0xb4, 0x1b, 0x87,
+	0xaf, 0xa0, 0xff, 0x5d, 0x6e, 0x5a, 0xc5, 0x54, 0x3e, 0x7f, 0xe4, 0xed, 0x5c, 0x1e, 0x20, 0x5f,
+	0x29, 0xbd, 0xec, 0x15, 0x9e, 0xc3, 0x73, 0x48, 0x95, 0x2e, 0xa7, 0x27, 0x8c, 0x4f, 0x02, 0xde,
+	0x59, 0x5f, 0xf6, 0x0a, 0x4a, 0xe3, 0x8b, 0x68, 0x39, 0x65, 0x0e, 0x8f, 0x39, 0xca, 0x50, 0x47,
+	0x46, 0x16, 0x43, 0x18, 0x58, 0x56, 0x12, 0x3f, 0x60, 0xf2, 0xb7, 0x30, 0xbe, 0x84, 0x41, 0x53,
+	0xd5, 0xdb, 0x4d, 0x74, 0xd8, 0xb5, 0xe2, 0x60, 0x34, 0x17, 0x18, 0x9c, 0xc3, 0xf0, 0xda, 0xd4,
+	0x5b, 0xd3, 0x76, 0x16, 0x4f, 0x03, 0xff, 0x36, 0x84, 0x63, 0x45, 0xc7, 0x2d, 0xee, 0x85, 0x11,
+	0x88, 0xdf, 0x09, 0xe4, 0x07, 0x6d, 0xf1, 0x09, 0x0c, 0x2b, 0xed, 0x6d, 0xb0, 0x78, 0x4a, 0x65,
+	0x31, 0x82, 0x02, 0xf2, 0xc6, 0xd9, 0x4a, 0xaf, 0x3d, 0x40, 0x6a, 0xa3, 0x65, 0xaf, 0x38, 0x0c,
+	0xe2, 0x73, 0xc8, 0xe8, 0x1f, 0x87, 0x29, 0xec, 0xa7, 0x25, 0x9d, 0xaa, 0x95, 0x76, 0xcb, 0x5e,
+	0xc1, 0x79, 0xb2, 0x4d, 0xe7, 0xc2, 0x94, 0xbb, 0x69, 0x76, 0x64, 0xbb, 0x63, 0x29, 0x47, 0xfa,
+	0x91, 0xdb, 0xdb, 0x7e, 0x03, 0xf7, 0x8f, 0x3e, 0x0e, 0x2f, 0x20, 0x5b, 0x51, 0xa7, 0xe4, 0x2c,
+	0x9d, 0xe5, 0xf3, 0x87, 0xa1, 0xd3, 0x47, 0xb5, 0xe3, 0xf4, 0x95, 0xac, 0x6c, 0xc1, 0x80, 0xf8,
+	0x00, 0xe3, 0xc3, 0x28, 0x4e, 0x20, 0xbd, 0x51, 0x71, 0x61, 0xe8, 0x8a, 0xb3, 0xb8, 0x1e, 0x27,
+	0xff, 0x1b, 0x7e, 0xd8, 0x0b, 0xf1, 0x14, 0xf2, 0x77, 0xd2, 0xc9, 0xb8, 0x7d, 0x08, 0xd9, 0x8d,
+	0xda, 0x35, 0xec, 0x61, 0x54, 0xf0, 0x5d, 0xfc, 0x4c, 0x00, 0x3c, 0xc3, 0xab, 0x77, 0x01, 0x59,
+	0x29, 0x9d, 0x0c, 0xff, 0xf5, 0x41, 0x68, 0x4d, 0xc0, 0xa7, 0xd5, 0x37, 0x75, 0xcd, 0xd3, 0x21,
+	0xe0, 0x4e, 0x57, 0x6e, 0xee, 0x2d, 0x79, 0xc5, 0x7f, 0x0c, 0x00, 0x83, 0x49, 0x12, 0x1f, 0x7b,
+	0x3f, 0xab, 0x01, 0x77, 0x7e, 0xfd, 0x27, 0x00, 0x00, 0xff, 0xff, 0xd2, 0xc1, 0x65, 0x36, 0xd3,
+	0x03, 0x00, 0x00,
 }

--- a/proto/node.proto
+++ b/proto/node.proto
@@ -3,11 +3,19 @@ package proto;
 
 import "stmt.proto";
 
-// node/ping
+// end of result stream marker
+message StreamEnd {}
+
+// stream errors
+message StreamError {
+  string error = 1;
+}
+
+// /mediachain/node/ping
 message Ping {}
 message Pong {}
 
-// node/query
+// /mediachain/node/query
 message QueryRequest {
   string query = 1;
 }
@@ -15,15 +23,9 @@ message QueryRequest {
 message QueryResult {
   oneof result {
     QueryResultValue value = 1;
-    QueryResultEnd end = 2;
-    QueryResultError error = 3;
+    StreamEnd end = 2;
+    StreamError error = 3;
   }
-}
-
-message QueryResultEnd {}
-
-message QueryResultError {
-  string error = 1;
 }
 
 message QueryResultValue {
@@ -51,4 +53,20 @@ message KeyValuePair {
   SimpleValue value = 2;
 }
 
+// /mediachain/node/data
+message DataRequest {
+  repeated string keys = 1;
+}
 
+message DataResult {
+  oneof result {
+    DataObject data = 1;
+    StreamEnd end = 2;
+    StreamError error = 3;
+  }
+}
+
+message DataObject {
+  string key = 1;
+  bytes data = 2;
+}

--- a/setup.sh
+++ b/setup.sh
@@ -14,5 +14,7 @@ gx --verbose install  || die
 echo "Installing unvendored deps"
 go get github.com/gorilla/mux github.com/mattn/go-sqlite3 || die
 
-echo "DONE"
+echo "Installing gorocksdb; this can take a while!"
+go get -tags=embed github.com/tecbot/gorocksdb || die
 
+echo "DONE"


### PR DESCRIPTION
Closes #36 

- Implements the datastore for statement metadata with rocksdb.
- Provide a `/data/put` and `/data/get` API endpoints for storing/retrieving metadata objects.
- Implement the `/mediachain/node/data` protocol for retrieving statement metadata from remote peers.
- Merge statement metadata along with statements in the merge implementation.

Note:
There is a minor change in the remote query protocol, as the end/error messages where refactored to be reused in the data protocol.

Datastore API details: 
- `/data/put` accepts a batch of DataObjects, which are json objects with a data field containing the data base-64 encoded, and returns a stream of object keys (which are B58-encoded SHA256 multihashes)
- `/data/get/{objectId}` retrieves a data object by its key or 404s.

Example:
```
$ head -c 20 /dev/urandom | base64
FCG389RpiSmWkbK96fd0if4gmhw=
$ curl -s -H "Content-Type: application/json" -d '{"data": "FCG389RpiSmWkbK96fd0if4gmhw="}' http://127.0.0.1:9002/data/put
QmT7KTeJYJ7pnvsUk8g56AqFgp1Cqk91HnuhyhmaYZW4dr
$ curl http://127.0.0.1:9002/data/get/QmT7KTeJYJ7pnvsUk8g56AqFgp1Cqk91HnuhyhmaYZW4dr
{"data":"FCG389RpiSmWkbK96fd0if4gmhw="}
```

Merge API changes:
- `/merge` will now fetch metadata referenced by the statements in the result sets, if it doesn't already have them in the datastore. 
  The API returns two integer values (instead of just one), the count of statements and objects that were merged.
  Missing metadata in the peer are treated as errors and abort the merge.

Example:
```
# the dataset contains a bunch of statements which all reference the same object
$ curl -H "Content-Type: application/text" -d 'SELECT * FROM * LIMIT 10' http://127.0.0.1:9004/merge/QmW5vgizcxphSSV22fKxxNCnv9TbaidYDiBCbHR9bGg2RM
10
1
$ curl -H "Content-Type: application/text" -d 'SELECT * FROM * LIMIT 10' http://127.0.0.1:9004/merge/QmW5vgizcxphSSV22fKxxNCnv9TbaidYDiBCbHR9bGg2RM
0
0
$ curl -H "Content-Type: application/text" -d 'SELECT * FROM * LIMIT 100' http://127.0.0.1:9004/merge/QmW5vgizcxphSSV22fKxxNCnv9TbaidYDiBCbHR9bGg2RM
90
0
```