### PR TITLE
Some small fixes

### DIFF
--- a/mcdir/main.go
+++ b/mcdir/main.go
@@ -10,6 +10,7 @@ import (
 	p2p_pstore "github.com/libp2p/go-libp2p-peerstore"
 	mc "github.com/mediachain/concat/mc"
 	pb "github.com/mediachain/concat/proto"
+	homedir "github.com/mitchellh/go-homedir"
 	"log"
 	"os"
 	"sync"
@@ -129,15 +130,26 @@ func (dir *Directory) lookupPeer(pid p2p_peer.ID) (p2p_pstore.PeerInfo, bool) {
 
 func main() {
 	port := flag.Int("l", 9000, "Listen port")
-	home := flag.String("d", "/tmp/mcdir", "Directory home")
+	hdir := flag.String("d", "~/.mediachain/mcdir", "Directory home")
 	flag.Parse()
 
-	err := os.MkdirAll(*home, 0755)
+	if len(flag.Args()) != 0 {
+		fmt.Fprintf(os.Stderr, "Usage: %s [options ...]\nOptions:\n", os.Args[0])
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	home, err := homedir.Expand(*hdir)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	id, err := mc.MakePeerIdentity(*home)
+	err = os.MkdirAll(home, 0755)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	id, err := mc.MakePeerIdentity(home)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/mcnode/db.go
+++ b/mcnode/db.go
@@ -50,6 +50,16 @@ func (sdb *SQLDB) Put(stmt *pb.Statement) error {
 }
 
 func (sdb *SQLDB) PutBatch(stmts []*pb.Statement) error {
+	// marshal statements before starting the tx, minimize critical section
+	data := make([][]byte, len(stmts))
+	for x, stmt := range stmts {
+		bytes, err := ggproto.Marshal(stmt)
+		if err != nil {
+			return err
+		}
+		data[x] = bytes
+	}
+
 	tx, err := sdb.db.Begin()
 	if err != nil {
 		return err
@@ -58,14 +68,8 @@ func (sdb *SQLDB) PutBatch(stmts []*pb.Statement) error {
 	insertStmtData := tx.Stmt(sdb.insertStmtData)
 	insertStmtEnvelope := tx.Stmt(sdb.insertStmtEnvelope)
 
-	for _, stmt := range stmts {
-		bytes, err := ggproto.Marshal(stmt)
-		if err != nil {
-			tx.Rollback()
-			return err
-		}
-
-		_, err = insertStmtData.Exec(stmt.Id, bytes)
+	for x, stmt := range stmts {
+		_, err = insertStmtData.Exec(stmt.Id, data[x])
 		if err != nil {
 			tx.Rollback()
 			return err

--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,7 @@ echo "Installing libp2p deps"
 gx --verbose install  || die
 
 echo "Installing unvendored deps"
-go get github.com/gorilla/mux github.com/mattn/go-sqlite3 || die
+go get github.com/gorilla/mux github.com/mattn/go-sqlite3 github.com/mitchellh/go-homedir || die
 
 echo "Installing gorocksdb; this can take a while!"
 go get -tags=embed github.com/tecbot/gorocksdb || die


### PR DESCRIPTION
A little leisurely Saturday morning hacking:
- Try to tune SQLDB.PutBatch by moving statement marshalling out of the transaction, which minimizecritical section time for concurrent writes -- Turns out this actually slows down ingestion, most likely because of blown cpu caches.
- Default the mcnode and mcdir home directories to ~/.mediachain/mc{node,dir} [#43]

Note: we have acquired a new unvendored dependency on go-homedir.