### PR TITLE
Future Proofing: Support merging multi-statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $ mcclient status
 offline
 ```
 
-At this point you can you should designate a directory for looking up peers:
+At this point you should designate a directory for looking up peers:
 ```
 $ mcclient config dir /ip4/54.173.71.205/tcp/9000/Qmb561BUvwc2pfMQ5NHb1uuwVE1hHWerySVMSUJLhnzNLN
 set directory to /ip4/54.173.71.205/tcp/9000/Qmb561BUvwc2pfMQ5NHb1uuwVE1hHWerySVMSUJLhnzNLN

--- a/mc/query/stmt.go
+++ b/mc/query/stmt.go
@@ -9,13 +9,72 @@ func StatementRefs(stmt *pb.Statement) []string {
 	case *pb.StatementBody_Simple:
 		return body.Simple.Refs
 
+	case *pb.StatementBody_Compound:
+		stmts := body.Compound.Body
+		count := 0
+		for _, stmt := range stmts {
+			count += len(stmt.Refs)
+		}
+		refs := make([]string, 0, count)
+		for _, stmt := range stmts {
+			refs = append(refs, stmt.Refs...)
+		}
+		return refs
+
+	case *pb.StatementBody_Envelope:
+		stmts := body.Envelope.Body
+		count := 0
+		for _, stmt := range stmts {
+			count += countStatementRefs(stmt)
+		}
+		refs := make([]string, 0, count)
+		for _, stmt := range stmts {
+			refs = append(refs, StatementRefs(stmt)...)
+		}
+		return refs
+
 	default:
-		// TODO compound statements etc
 		return nil
 	}
 }
 
+func countStatementRefs(stmt *pb.Statement) int {
+	switch body := stmt.Body.Body.(type) {
+	case *pb.StatementBody_Simple:
+		return len(body.Simple.Refs)
+
+	case *pb.StatementBody_Compound:
+		stmts := body.Compound.Body
+		count := 0
+		for _, stmt := range stmts {
+			count += len(stmt.Refs)
+		}
+		return count
+
+	case *pb.StatementBody_Envelope:
+		stmts := body.Envelope.Body
+		count := 0
+		for _, stmt := range stmts {
+			count += countStatementRefs(stmt)
+		}
+		return count
+
+	default:
+		return 0
+	}
+}
+
 func StatementSource(stmt *pb.Statement) string {
-	// TODO compound statements etc
-	return stmt.Publisher
+	switch body := stmt.Body.Body.(type) {
+	case *pb.StatementBody_Envelope:
+		// that's just the source of the first statement; all envelope statements
+		// should have the same source
+		if len(body.Envelope.Body) > 0 {
+			return StatementSource(body.Envelope.Body[0])
+		}
+		return stmt.Publisher
+
+	default:
+		return stmt.Publisher
+	}
 }


### PR DESCRIPTION
Last merge for v1.0:
Implement the necessary logic to support merging multi-statements (compound or envelopes) so that v1.0 release mcnode is forward compatible.
