### PR TITLE
Automatic packaging and deployment for tagged releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+dist
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: trusty
 
 # copy previously cached deps into GOPATH
 before_install:
-  - if [ -d "$HOME/gocache/src" && -d "$HOME/gocache/pkg" ]; then rsync "$HOME/gocache/" "$GOPATH/"; fi
+  - if [[ -d "$HOME/gocache/src" && -d "$HOME/gocache/pkg" ]]; then rsync "$HOME/gocache/" "$GOPATH/"; fi
 
 install:
   - go get -u github.com/whyrusleeping/gx

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,8 @@ before_install:
   - if [[ -d "$HOME/gocache/src" && -d "$HOME/gocache/pkg" ]]; then rsync -a "$HOME/gocache/" "$GOPATH/"; fi
 
 install:
-  - go get -u github.com/whyrusleeping/gx
-  - go get -u github.com/whyrusleeping/gx-go
-  - gx install
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX="g++-4.8" CC="gcc-4.8" CXXFLAGS="-stdlib=libc++" LDFLAGS="-stdlib=libc++ -std=c++11 -lrt -Wl,--no-as-needed"; fi
-  - gx-go rewrite && go get -tags=embed ./...
+  - ./setup.sh
   - ./install.sh
   - ./package.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,24 +4,31 @@ go:
 sudo: required
 dist: trusty
 
+# copy previously cached deps into GOPATH
+before_install:
+  - if [ -d "$HOME/gocache/src" && -d "$HOME/gocache/pkg" ]; then rsync "$HOME/gocache/" "$GOPATH/"; fi
+
 install:
   - go get -u github.com/whyrusleeping/gx
   - go get -u github.com/whyrusleeping/gx-go
   - gx install
   - gx-go rewrite && env CXX="g++-4.8" CC="gcc-4.8" CXXFLAGS="-stdlib=libc++" LDFLAGS="-stdlib=libc++ -std=c++11 -lrt -Wl,--no-as-needed" go get -tags=embed ./...
   - ./install.sh
+  - ./package.sh
 
 script: gx-go rewrite && go test ./mc/...
 
-# don't cache our source dir
+# copy expensive go dependencies to $HOME/gocache dir, where travis will cache them
 before_cache:
-  - rm -rf $GOPATH/src/github.com/mediachain/concat
+  - mkdir -p $HOME/gocache/src $HOME/gocache/pkg
+  - rsync $GOPATH/src/ $HOME/gocache/src/
+  - rsync $GOPATH/pkg/ $HOME/gocache/pkg/
+  - rm -rf $HOME/gocache/src/github.com/mediachain/concat
 
 # cache go dependencies (espeically /pkg with gorocksdb)
 cache:
   directories:
-    - $GOPATH/src
-    - $GOPATH/pkg
+    - $HOME/gocache
 
 addons:
   apt:
@@ -30,3 +37,16 @@ addons:
     packages:
       - gcc-4.8
       - g++-4.8
+
+deploy:
+  skip_cleanup: true
+  provider: releases
+  api_key:
+    secure: Rna+kIBeoIrW9HXhf2k9OFbXXHniVemE0m4VAHJUqCJhUmItdOMOPosNridzFZIH3Ophmm5oittg/Sb8nxVk6XRoZ4ZhCj5phbAv08+fm9ld5xGCu5OhGnVKsqL3uOgApOxIZusY/bR2UFDFgi8R/ZoYDC8cmqZXetP8Ig4Twb33t9p2ehzhCa4LHD4XeYu0NrlvqICQsM6pPkkVBHa3V6hzwaee75TZnRWcQTQZ2vU90QZyIuvLL5+E9R9aqOUy3LzghTQ08fqFNkX15BerctkCYkLzeyKzRKl0KJ61lOILsisRNaI9LxToR83gLem4WEBNseoRbbOJ5g8U7qsfsiMDzxERXXsEoJswfuof/wKGO92faZNoMrXbdTZbCD1L55fG3AvdTrmqhE0QfG26PjjNB6jvJ7KAU1LcNsJPRUbD/vwOau8W03nJt/BsZayF4mQi685YS+DRPsEbyiTzDHZd5el57k6d97B1fowlzLcvTkAm8uKvKifEmgG0gp4FPeeO2mjo72zLWnVMfzBGbFoWnvAIomt/4003fP/dQcxiEw5OWR3qk2O83cSUAaAdAcHALFqTQUT3WQoX9VT/JMwRbPs3DcDDbPe3tdKFEEmfabOq5M7L7JrShTiXvfxu5fh73shPbJVWCodzYZWEo7zNPfd+ZrJxZFk+BLVrmgc=
+  file_glob: true
+  file: 'dist/*.tgz'
+  on:
+    repo: mediachain/concat
+    tags: true
+    # only upload a release if we're on a commit whose tag starts with 'v'
+    condition: $(git describe --tags) == v*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.7
+  - 1.7.1
 sudo: required
 dist: trusty
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: trusty
 
 # copy previously cached deps into GOPATH
 before_install:
-  - if [[ -d "$HOME/gocache/src" && -d "$HOME/gocache/pkg" ]]; then rsync "$HOME/gocache/" "$GOPATH/"; fi
+  - if [[ -d "$HOME/gocache/src" && -d "$HOME/gocache/pkg" ]]; then rsync -a "$HOME/gocache/" "$GOPATH/"; fi
 
 install:
   - go get -u github.com/whyrusleeping/gx
@@ -21,8 +21,8 @@ script: gx-go rewrite && go test ./mc/...
 # copy expensive go dependencies to $HOME/gocache dir, where travis will cache them
 before_cache:
   - mkdir -p $HOME/gocache/src $HOME/gocache/pkg
-  - rsync $GOPATH/src/ $HOME/gocache/src/
-  - rsync $GOPATH/pkg/ $HOME/gocache/pkg/
+  - rsync -a $GOPATH/src/ $HOME/gocache/src/
+  - rsync -a $GOPATH/pkg/ $HOME/gocache/pkg/
   - rm -rf $HOME/gocache/src/github.com/mediachain/concat
 
 # cache go dependencies (espeically /pkg with gorocksdb)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ go:
   - 1.7
 sudo: required
 dist: trusty
+os:
+  - linux
+  - osx
 
 # copy previously cached deps into GOPATH
 before_install:
@@ -12,7 +15,8 @@ install:
   - go get -u github.com/whyrusleeping/gx
   - go get -u github.com/whyrusleeping/gx-go
   - gx install
-  - gx-go rewrite && env CXX="g++-4.8" CC="gcc-4.8" CXXFLAGS="-stdlib=libc++" LDFLAGS="-stdlib=libc++ -std=c++11 -lrt -Wl,--no-as-needed" go get -tags=embed ./...
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX="g++-4.8" CC="gcc-4.8" CXXFLAGS="-stdlib=libc++" LDFLAGS="-stdlib=libc++ -std=c++11 -lrt -Wl,--no-as-needed"; fi
+  - gx-go rewrite && go get -tags=embed ./...
   - ./install.sh
   - ./package.sh
 

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+OS_NAME=$(go env GOOS)
+ARCH_NAME=$(go env GOARCH)
+
+VERSION_STR=""
+LAST_TAG=$(git describe --tags 2>/dev/null)
+if [[ "${LAST_TAG}" == v* ]]; then
+  VERSION_STR="-${LAST_TAG}"
+fi
+
+function make_tarball {
+ prog=$1
+ bin_dir=$2
+ suffix=$3
+ outfile="${PWD}/dist/${prog}${VERSION_STR}-${OS_NAME}-${ARCH_NAME}${suffix}.tgz"
+ echo "creating package: ${outfile}"
+ tar czf "${outfile}" -C "${bin_dir}" "${prog}"
+}
+
+mkdir -p ${PWD}/dist
+
+if [ "$OS_NAME" == "linux" ]; then
+  strip -o /tmp/mcnode ${GOPATH}/bin/mcnode
+  strip -o /tmp/mcdir ${GOPATH}/bin/mcdir
+  make_tarball mcnode /tmp
+  make_tarball mcdir /tmp
+  make_tarball mcnode ${GOPATH}/bin -unstripped
+  make_tarball mcdir ${GOPATH}/bin -unstripped
+else
+  make_tarball mcnode ${GOPATH}/bin
+  make_tarball mcdir ${GOPATH}/bin
+fi


### PR DESCRIPTION
This sets up automatic deployment to github releases when you tag a commit with a tag starting with `v`
- adds `package.sh` to generate tarballs in `./dist`
  - filenames are of the form `mcnode-${version}-${os}-${arch}.tgz`
  - on linux, runs `strip` before generating the main tarball, and also makes a `-unstripped` variant

updates to travis.yml:
- cache go dependencies between builds (huge speed improvement)
- build for osx and linux
- deploy to github releases if commit is tagged and tag starts with `v`

One quirk is that the releases are marked as public (taken out of Draft status) when the upload completes, and it's not aware that we're building for more than one OS.  Since mac builds tend to get stuck in the queue for a while, releases will probably be lacking mac binaries for a little bit until the mac build completes.
