### PR TITLE
Compound Statement publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ A REST API is provided for controlling the node. This is an administrative inter
 * `GET /id/{peerId}` -- node info for peer given by peerId
 * `GET /ping/{peerId}` -- ping!
 * `POST /publish/{namespace}` -- publish a batch of statements to the specified namespace 
+* `POST /publish/{namespace}/{combine}` -- publish a batch of statements with CompoundStatement grouping 
 * `GET /stmt/{statementId}` -- retrieve statement by statementId
 * `POST /query` -- issue MCQL SELECT query on the local node
 * `POST /query/{peerId}` -- issue MCQL SELECT query on a remote peer

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -74,6 +74,7 @@ func main() {
 	router.HandleFunc("/id/{peerId}", node.httpRemoteId)
 	router.HandleFunc("/ping/{peerId}", node.httpPing)
 	router.HandleFunc("/publish/{namespace}", node.httpPublish)
+	router.HandleFunc("/publish/{namespace}/{combine}", node.httpPublishCompound)
 	router.HandleFunc("/stmt/{statementId}", node.httpStatement)
 	router.HandleFunc("/query", node.httpQuery)
 	router.HandleFunc("/query/{peerId}", node.httpRemoteQuery)

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -885,7 +885,10 @@ func (node *Node) doMergeDataImpl(s p2p_net.Stream, keys map[string]Key) (count 
 
 loop:
 	for {
-		err = r.ReadMsg(&res)
+		err := r.ReadMsg(&res)
+		if err != nil {
+			return count, err
+		}
 
 		switch res := res.Result.(type) {
 		case *pb.DataResult_Data:


### PR DESCRIPTION
Extends the `/publish/ns` endpoint with a `/publish/ns/N`, which publishes compound statements in groups of N [#62]

Also fixes a missing error check in mergeDataImpl.

Demo:

```
$ wc -l /tmp/batch100 
100 /tmp/batch100

$ head -5 /tmp/batch100
{"object": "QmSiRz7p3y7Y3fYcvxdHRv2gAmKaQ21tjrKMu3Cgq215uj", "refs": ["abc"], "tags": ["test"]}
{"object": "QmTJqrdXaxkrR3rW4VMMzPVkzHZrnHoDgY1WnhVxhQa3Sa", "refs": ["abc"], "tags": ["test"]}
{"object": "QmZw5rJokTsayoKi1rDehFS1WfefsoXyFXVzuMJwt8baJj", "refs": ["abc"], "tags": ["test"]}
{"object": "QmSiRz7p3y7Y3fYcvxdHRv2gAmKaQ21tjrKMu3Cgq215uj", "refs": ["abc"], "tags": ["test"]}
{"object": "QmTJqrdXaxkrR3rW4VMMzPVkzHZrnHoDgY1WnhVxhQa3Sa", "refs": ["abc"], "tags": ["test"]}

$ curl -s -H "Content-Type: application/json" -d "@/tmp/batch100" http://127.0.0.1:9002/publish/a.b.c/10
4XTTMGReLUMFwj68shYTzHBo3BDd3SRnY12jRoBwBiwd3aoVk:1477651493:0
4XTTMGReLUMFwj68shYTzHBo3BDd3SRnY12jRoBwBiwd3aoVk:1477651493:1
4XTTMGReLUMFwj68shYTzHBo3BDd3SRnY12jRoBwBiwd3aoVk:1477651493:2
4XTTMGReLUMFwj68shYTzHBo3BDd3SRnY12jRoBwBiwd3aoVk:1477651493:3
4XTTMGReLUMFwj68shYTzHBo3BDd3SRnY12jRoBwBiwd3aoVk:1477651493:4
4XTTMGReLUMFwj68shYTzHBo3BDd3SRnY12jRoBwBiwd3aoVk:1477651493:5
4XTTMGReLUMFwj68shYTzHBo3BDd3SRnY12jRoBwBiwd3aoVk:1477651493:6
4XTTMGReLUMFwj68shYTzHBo3BDd3SRnY12jRoBwBiwd3aoVk:1477651493:7
4XTTMGReLUMFwj68shYTzHBo3BDd3SRnY12jRoBwBiwd3aoVk:1477651493:8
4XTTMGReLUMFwj68shYTzHBo3BDd3SRnY12jRoBwBiwd3aoVk:1477651493:9

$ mcclient query "SELECT * FROM * LIMIT 1"
{ id: '4XTTMGReLUMFwj68shYTzHBo3BDd3SRnY12jRoBwBiwd3aoVk:1477651493:0',
  publisher: '4XTTMGReLUMFwj68shYTzHBo3BDd3SRnY12jRoBwBiwd3aoVk',
  namespace: 'a.b.c',
  body: 
   { Body: 
      { Compound: 
         { body: 
            [ { object: 'QmSiRz7p3y7Y3fYcvxdHRv2gAmKaQ21tjrKMu3Cgq215uj',
                refs: [ 'abc' ],
                tags: [ 'test' ] },
              { object: 'QmTJqrdXaxkrR3rW4VMMzPVkzHZrnHoDgY1WnhVxhQa3Sa',
                refs: [ 'abc' ],
                tags: [ 'test' ] },
              { object: 'QmZw5rJokTsayoKi1rDehFS1WfefsoXyFXVzuMJwt8baJj',
                refs: [ 'abc' ],
                tags: [ 'test' ] },
              { object: 'QmSiRz7p3y7Y3fYcvxdHRv2gAmKaQ21tjrKMu3Cgq215uj',
                refs: [ 'abc' ],
                tags: [ 'test' ] },
              { object: 'QmTJqrdXaxkrR3rW4VMMzPVkzHZrnHoDgY1WnhVxhQa3Sa',
                refs: [ 'abc' ],
                tags: [ 'test' ] },
              { object: 'QmZw5rJokTsayoKi1rDehFS1WfefsoXyFXVzuMJwt8baJj',
                refs: [ 'abc' ],
                tags: [ 'test' ] },
              { object: 'QmSiRz7p3y7Y3fYcvxdHRv2gAmKaQ21tjrKMu3Cgq215uj',
                refs: [ 'abc' ],
                tags: [ 'test' ] },
              { object: 'QmTJqrdXaxkrR3rW4VMMzPVkzHZrnHoDgY1WnhVxhQa3Sa',
                refs: [ 'abc' ],
                tags: [ 'test' ] },
              { object: 'QmZw5rJokTsayoKi1rDehFS1WfefsoXyFXVzuMJwt8baJj',
                refs: [ 'abc' ],
                tags: [ 'test' ] },
              { object: 'QmSiRz7p3y7Y3fYcvxdHRv2gAmKaQ21tjrKMu3Cgq215uj',
                refs: [ 'abc' ],
                tags: [ 'test' ] } ] } } },
  timestamp: 1477651493,
  signature: 'fB+oCJH4I4wRm0iteiRtVHft+lPNRdcDptedzVRzn3LUISfsVm4rLlTxbGZlMz2TTTddH08inq5ce2qs0FCEDQ==' }
```
