### PR TITLE
Small networking fixes

### DIFF
--- a/mc/util.go
+++ b/mc/util.go
@@ -71,14 +71,19 @@ func ParseHandleId(str string) (empty p2p_pstore.PeerInfo, err error) {
 // re-export this option to avoid basic host interface leakage
 const NATPortMap = p2p_bhost.NATPortMap
 
-func NewHost(id PeerIdentity, laddr multiaddr.Multiaddr, opts ...interface{}) (p2p_host.Host, error) {
+func NewHost(ctx context.Context, id PeerIdentity, laddr multiaddr.Multiaddr, opts ...interface{}) (p2p_host.Host, error) {
 	pstore := p2p_pstore.NewPeerstore()
 	pstore.AddPrivKey(id.ID, id.PrivKey)
 	pstore.AddPubKey(id.ID, id.PrivKey.GetPublic())
 
+	var addrs []multiaddr.Multiaddr
+	if laddr != nil {
+		addrs = []multiaddr.Multiaddr{laddr}
+	}
+
 	netw, err := p2p_swarm.NewNetwork(
 		context.Background(),
-		[]multiaddr.Multiaddr{laddr},
+		addrs,
 		id.ID,
 		pstore,
 		p2p_metrics.NewBandwidthCounter())

--- a/mcdir/main.go
+++ b/mcdir/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	ggio "github.com/gogo/protobuf/io"
@@ -197,7 +198,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	host, err := mc.NewHost(id, addr)
+	host, err := mc.NewHost(context.Background(), id, addr)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -112,6 +112,11 @@ func (node *Node) goPublic() error {
 		if err != nil {
 			return err
 		}
+
+		if node.natCfg.Opt == mc.NATConfigAuto {
+			// wait a bit for NAT port mapping to take effect
+			time.Sleep(2 * time.Second)
+		}
 		fallthrough
 
 	case StatusOnline:

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -78,7 +78,7 @@ func (node *Node) _goOnline() error {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	host, err := mc.NewHost(ctx, node.PeerIdentity, node.laddr, opts...)
+	host, err := mc.NewHost(ctx, node.PeerIdentity, nil, opts...)
 	if err != nil {
 		cancel()
 		return err
@@ -88,6 +88,13 @@ func (node *Node) _goOnline() error {
 	host.SetStreamHandler("/mediachain/node/ping", node.pingHandler)
 	host.SetStreamHandler("/mediachain/node/query", node.queryHandler)
 	host.SetStreamHandler("/mediachain/node/data", node.dataHandler)
+
+	err = host.Network().Listen(node.laddr)
+	if err != nil {
+		cancel()
+		host.Close()
+		return err
+	}
 
 	node.host = host
 	node.netCtx = ctx

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -78,7 +78,7 @@ func (node *Node) _goOnline() error {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	host, err := mc.NewHost(ctx, node.PeerIdentity, nil, opts...)
+	host, err := mc.NewHost(ctx, node.PeerIdentity, node.laddr, opts...)
 	if err != nil {
 		cancel()
 		return err
@@ -88,13 +88,6 @@ func (node *Node) _goOnline() error {
 	host.SetStreamHandler("/mediachain/node/ping", node.pingHandler)
 	host.SetStreamHandler("/mediachain/node/query", node.queryHandler)
 	host.SetStreamHandler("/mediachain/node/data", node.dataHandler)
-
-	err = host.Network().Listen(node.laddr)
-	if err != nil {
-		cancel()
-		host.Close()
-		return err
-	}
 
 	node.host = host
 	node.netCtx = ctx

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -77,8 +77,10 @@ func (node *Node) _goOnline() error {
 		opts = []interface{}{mc.NATPortMap}
 	}
 
-	host, err := mc.NewHost(node.PeerIdentity, node.laddr, opts...)
+	ctx, cancel := context.WithCancel(context.Background())
+	host, err := mc.NewHost(ctx, node.PeerIdentity, node.laddr, opts...)
 	if err != nil {
+		cancel()
 		return err
 	}
 
@@ -86,9 +88,8 @@ func (node *Node) _goOnline() error {
 	host.SetStreamHandler("/mediachain/node/ping", node.pingHandler)
 	host.SetStreamHandler("/mediachain/node/query", node.queryHandler)
 	host.SetStreamHandler("/mediachain/node/data", node.dataHandler)
-	node.host = host
 
-	ctx, cancel := context.WithCancel(context.Background())
+	node.host = host
 	node.netCtx = ctx
 	node.netCancel = cancel
 


### PR DESCRIPTION
Changes in mc.NewHost:
- client owns the context used by the swarm network object
- allow nil address for delayed binding.

Change in mcnode/proto
- Adds a delay in the offline->online->public transition when NATConfig = auto, so that port mapping can complete before the first directory registration attempt.