### PR TITLE
Datastore Garbage Collection

### DIFF
--- a/mc/util.go
+++ b/mc/util.go
@@ -23,6 +23,14 @@ func Hash(data []byte) multihash.Multihash {
 	return mh
 }
 
+func HashFromBytes(hash []byte) multihash.Multihash {
+	mhash := make([]byte, len(hash)+2)
+	mhash[0] = multihash.SHA2_256
+	mhash[1] = 32
+	copy(mhash[2:], hash)
+	return mhash
+}
+
 func ParseAddress(str string) (multiaddr.Multiaddr, error) {
 	return multiaddr.NewMultiaddr(str)
 }

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -637,7 +637,7 @@ func (node *Node) httpGCData(w http.ResponseWriter, r *http.Request) {
 }
 
 // POST /data/compact
-// compact the datastore; useful for immediately reclaiming space following a gc
+// compact the datastore
 func (node *Node) httpCompactData(w http.ResponseWriter, r *http.Request) {
 	err := node.doCompact()
 	if err != nil {
@@ -649,7 +649,7 @@ func (node *Node) httpCompactData(w http.ResponseWriter, r *http.Request) {
 }
 
 // POST /data/sync
-// sync the datastore; useful for immediately reclaiming space following a merge
+// flushes the datastore; useful for immediately reclaiming space used by the WAL
 func (node *Node) httpSyncData(w http.ResponseWriter, r *http.Request) {
 	err := node.ds.Sync()
 	if err != nil {

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -648,6 +648,18 @@ func (node *Node) httpCompactData(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, "OK")
 }
 
+// POST /data/sync
+// sync the datastore; useful for immediately reclaiming space following a merge
+func (node *Node) httpSyncData(w http.ResponseWriter, r *http.Request) {
+	err := node.ds.Sync()
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	fmt.Fprintln(w, "OK")
+}
+
 func (node *Node) httpDataKeys(w http.ResponseWriter, r *http.Request) {
 	keys, err := node.ds.IterKeys(r.Context())
 	if err != nil {

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -618,6 +618,15 @@ func (node *Node) httpMergeData(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, count)
 }
 
+// POST /data/gc
+// garbage collect orphan data objects that are not referenced by any statement
+func (node *Node) httpGCData(w http.ResponseWriter, r *http.Request) {
+	// XXX this just dumps the ds keys to test iterators
+	for key := range node.ds.IterKeys(r.Context()) {
+		fmt.Fprintln(w, multihash.Multihash(key).B58String())
+	}
+}
+
 // GET /status
 // Returns the node network state
 func (node *Node) httpStatus(w http.ResponseWriter, r *http.Request) {

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -649,7 +649,13 @@ func (node *Node) httpCompactData(w http.ResponseWriter, r *http.Request) {
 }
 
 func (node *Node) httpDataKeys(w http.ResponseWriter, r *http.Request) {
-	for key := range node.ds.IterKeys(r.Context()) {
+	keys, err := node.ds.IterKeys(r.Context())
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	for key := range keys {
 		fmt.Fprintln(w, multihash.Multihash(key).B58String())
 	}
 }

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -621,7 +621,10 @@ func (node *Node) httpMergeData(w http.ResponseWriter, r *http.Request) {
 // POST /data/gc
 // garbage collect orphan data objects that are not referenced by any statement
 func (node *Node) httpGCData(w http.ResponseWriter, r *http.Request) {
-	// XXX this just dumps the ds keys to test iterators
+
+}
+
+func (node *Node) httpDataKeys(w http.ResponseWriter, r *http.Request) {
 	for key := range node.ds.IterKeys(r.Context()) {
 		fmt.Fprintln(w, multihash.Multihash(key).B58String())
 	}

--- a/mcnode/ds.go
+++ b/mcnode/ds.go
@@ -112,10 +112,10 @@ func (ds *RocksDS) Sync() error {
 	return ds.db.Flush(ds.fo)
 }
 
-func (ds *RocksDS) IterKeys(ctx context.Context) <-chan Key {
+func (ds *RocksDS) IterKeys(ctx context.Context) (<-chan Key, error) {
 	err := ds.Sync()
 	if err != nil {
-		log.Printf("Errof flushing rocksdb: %s", err.Error())
+		return nil, err
 	}
 
 	ch := make(chan Key)
@@ -137,7 +137,7 @@ func (ds *RocksDS) IterKeys(ctx context.Context) <-chan Key {
 			}
 		}
 	}()
-	return ch
+	return ch, nil
 }
 
 func (ds *RocksDS) Compact() {

--- a/mcnode/ds.go
+++ b/mcnode/ds.go
@@ -129,6 +129,10 @@ func (ds *RocksDS) IterKeys(ctx context.Context) <-chan Key {
 	return ch
 }
 
+func (ds *RocksDS) Compact() {
+	ds.db.CompactRange(rocksdb.Range{})
+}
+
 func (ds *RocksDS) Close() {
 	ds.db.Close()
 }

--- a/mcnode/gc.go
+++ b/mcnode/gc.go
@@ -2,12 +2,26 @@ package main
 
 import (
 	"context"
+	"errors"
+)
+
+var (
+	NodeMustBeOffline = errors.New("Node must be offline")
 )
 
 func (node *Node) doGC(ctx context.Context) (int, error) {
+	if node.status != StatusOffline {
+		return 0, NodeMustBeOffline
+	}
+
 	return 0, nil
 }
 
 func (node *Node) doCompact() error {
+	if node.status != StatusOffline {
+		return NodeMustBeOffline
+	}
+
+	node.ds.Compact()
 	return nil
 }

--- a/mcnode/gc.go
+++ b/mcnode/gc.go
@@ -35,10 +35,6 @@ func (node *Node) doGC(ctx context.Context) (int, error) {
 }
 
 func (node *Node) doCompact() error {
-	if node.status != StatusOffline {
-		return NodeMustBeOffline
-	}
-
 	node.ds.Compact()
 	return nil
 }

--- a/mcnode/gc.go
+++ b/mcnode/gc.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 )
 
@@ -14,7 +15,19 @@ func (node *Node) doGC(ctx context.Context) (int, error) {
 		return 0, NodeMustBeOffline
 	}
 
-	return 0, nil
+	gc := &GCDB{}
+	err := gc.Open(node.home)
+	if err != nil {
+		return 0, err
+	}
+	defer gc.Close()
+
+	err = gc.Merge(node.db)
+	if err != nil {
+		return 0, err
+	}
+
+	return gc.GC(node.ds)
 }
 
 func (node *Node) doCompact() error {
@@ -24,4 +37,24 @@ func (node *Node) doCompact() error {
 
 	node.ds.Compact()
 	return nil
+}
+
+type GCDB struct {
+	db *sql.DB
+}
+
+func (gc *GCDB) Open(home string) error {
+	return nil
+}
+
+func (gc *GCDB) Close() {
+
+}
+
+func (gc *GCDB) Merge(db StatementDB) error {
+	return nil
+}
+
+func (gc *GCDB) GC(ds Datastore) (int, error) {
+	return 0, nil
 }

--- a/mcnode/gc.go
+++ b/mcnode/gc.go
@@ -50,7 +50,7 @@ type GCDB struct {
 }
 
 func (gc *GCDB) Open(home string) error {
-	// TODO on-disk index for large deletions
+	// TODO on-disk index for large datasets
 	const dbpath = ":memory:"
 	db, err := sql.Open("sqlite3", dbpath)
 	if err != nil {

--- a/mcnode/gc.go
+++ b/mcnode/gc.go
@@ -207,7 +207,7 @@ func (gc *GCDB) GC(ctx context.Context, ds Datastore) (count int, err error) {
 	}
 
 	if count > 0 {
-		err = ds.Sync()
+		ds.Compact()
 	}
 
 	return

--- a/mcnode/gc.go
+++ b/mcnode/gc.go
@@ -50,12 +50,37 @@ type GCDB struct {
 }
 
 func (gc *GCDB) Open(home string) error {
-	// XXX Implement me!
+	// TODO on-disk index for large deletions
+	const dbpath = ":memory:"
+	db, err := sql.Open("sqlite3", dbpath)
+	if err != nil {
+		return err
+	}
+	gc.db = db
+
+	_, err = db.Exec("CREATE TABLE Refs (key VARCHAR(64) PRIMARY KEY)")
+	if err != nil {
+		return err
+	}
+
+	insertKey, err := db.Prepare("INSERT INTO Refs VALUES (?)")
+	if err != nil {
+		return err
+	}
+	gc.insertKey = insertKey
+
+	countKeys, err := db.Prepare("SELECT COUNT(1) FROM Refs WHERE key = ?")
+	if err != nil {
+		return err
+	}
+	gc.countKeys = countKeys
+
 	return nil
 }
 
-func (gc *GCDB) Close() {
-	// XXX Implement me!
+func (gc *GCDB) Close() error {
+	// TODO clear on-disk index
+	return gc.db.Close()
 }
 
 func (gc *GCDB) Merge(ctx context.Context, db StatementDB) error {

--- a/mcnode/gc.go
+++ b/mcnode/gc.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	sqlite3 "github.com/mattn/go-sqlite3"
+	mcq "github.com/mediachain/concat/mc/query"
+	pb "github.com/mediachain/concat/proto"
 )
 
 var (
@@ -22,12 +25,12 @@ func (node *Node) doGC(ctx context.Context) (int, error) {
 	}
 	defer gc.Close()
 
-	err = gc.Merge(node.db)
+	err = gc.Merge(ctx, node.db)
 	if err != nil {
 		return 0, err
 	}
 
-	return gc.GC(node.ds)
+	return gc.GC(ctx, node.ds)
 }
 
 func (node *Node) doCompact() error {
@@ -40,21 +43,119 @@ func (node *Node) doCompact() error {
 }
 
 type GCDB struct {
-	db *sql.DB
+	db        *sql.DB
+	insertKey *sql.Stmt
 }
 
 func (gc *GCDB) Open(home string) error {
+	// XXX Implement me!
 	return nil
 }
 
 func (gc *GCDB) Close() {
-
+	// XXX Implement me!
 }
 
-func (gc *GCDB) Merge(db StatementDB) error {
+func (gc *GCDB) Merge(ctx context.Context, db StatementDB) error {
+	q, err := mcq.ParseQuery("SELECT * FROM *")
+	if err != nil {
+		return err
+	}
+
+	ch, err := db.QueryStream(ctx, q)
+	if err != nil {
+		return err
+	}
+
+	const batch = 1024
+	keys := make(map[string]bool)
+
+	for val := range ch {
+		switch val := val.(type) {
+		case *pb.Statement:
+			gc.addKeys(val, keys)
+			if len(keys) >= batch {
+				err := gc.mergeKeys(keys)
+				if err != nil {
+					return err
+				}
+				keys = make(map[string]bool)
+			}
+
+		case StreamError:
+			return val
+
+		default:
+			return BadResult
+		}
+	}
+
+	if len(keys) > 0 {
+		return gc.mergeKeys(keys)
+	}
+
 	return nil
 }
 
-func (gc *GCDB) GC(ds Datastore) (int, error) {
+func (gc *GCDB) addKeys(stmt *pb.Statement, keys map[string]bool) error {
+	switch body := stmt.Body.Body.(type) {
+	case *pb.StatementBody_Simple:
+		gc.addSimpleKeys(body.Simple, keys)
+		return nil
+
+	case *pb.StatementBody_Compound:
+		ss := body.Compound.Body
+		for _, s := range ss {
+			gc.addSimpleKeys(s, keys)
+		}
+		return nil
+
+	case *pb.StatementBody_Envelope:
+		stmts := body.Envelope.Body
+		for _, stmt := range stmts {
+			err := gc.addKeys(stmt, keys)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+
+	default:
+		return BadStatementBody
+	}
+}
+
+func (gc *GCDB) addSimpleKeys(s *pb.SimpleStatement, keys map[string]bool) {
+	keys[s.Object] = true
+	for _, dep := range s.Deps {
+		keys[dep] = true
+	}
+}
+
+func (gc *GCDB) mergeKeys(keys map[string]bool) error {
+	tx, err := gc.db.Begin()
+	if err != nil {
+		return err
+	}
+
+	insertKey := tx.Stmt(gc.insertKey)
+
+	for key, _ := range keys {
+		_, err := insertKey.Exec(key)
+		if err != nil {
+			xerr, ok := err.(sqlite3.Error)
+			if ok && xerr.ExtendedCode == sqlite3.ErrConstraintPrimaryKey {
+				continue
+			}
+			tx.Rollback()
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (gc *GCDB) GC(ctx context.Context, ds Datastore) (int, error) {
+	// XXX Implement me!
 	return 0, nil
 }

--- a/mcnode/gc.go
+++ b/mcnode/gc.go
@@ -201,6 +201,10 @@ func (gc *GCDB) GC(ctx context.Context, ds Datastore) (count int, err error) {
 		count += 1
 	}
 
+	if count > 0 {
+		ds.Sync()
+	}
+
 	return
 }
 

--- a/mcnode/gc.go
+++ b/mcnode/gc.go
@@ -207,7 +207,7 @@ func (gc *GCDB) GC(ctx context.Context, ds Datastore) (count int, err error) {
 	}
 
 	if count > 0 {
-		ds.Sync()
+		err = ds.Sync()
 	}
 
 	return

--- a/mcnode/gc.go
+++ b/mcnode/gc.go
@@ -183,7 +183,12 @@ func (gc *GCDB) mergeKeys(keys map[string]bool) error {
 }
 
 func (gc *GCDB) GC(ctx context.Context, ds Datastore) (count int, err error) {
-	for key := range ds.IterKeys(ctx) {
+	keys, err := ds.IterKeys(ctx)
+	if err != nil {
+		return
+	}
+
+	for key := range keys {
 		var valid bool
 		valid, err = gc.validKey(key)
 		if err != nil {

--- a/mcnode/gc.go
+++ b/mcnode/gc.go
@@ -50,9 +50,7 @@ type GCDB struct {
 }
 
 func (gc *GCDB) Open(home string) error {
-	// TODO on-disk index for large datasets
-	const dbpath = ":memory:"
-	db, err := sql.Open("sqlite3", dbpath)
+	db, err := sql.Open("sqlite3", "") // use temporary db
 	if err != nil {
 		return err
 	}
@@ -79,7 +77,6 @@ func (gc *GCDB) Open(home string) error {
 }
 
 func (gc *GCDB) Close() error {
-	// TODO clear on-disk index
 	return gc.db.Close()
 }
 

--- a/mcnode/gc.go
+++ b/mcnode/gc.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"context"
+)
+
+func (node *Node) doGC(ctx context.Context) (int, error) {
+	return 0, nil
+}
+
+func (node *Node) doCompact() error {
+	return nil
+}

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -87,6 +87,7 @@ func main() {
 	router.HandleFunc("/data/keys", node.httpDataKeys)
 	router.HandleFunc("/data/gc", node.httpGCData)
 	router.HandleFunc("/data/compact", node.httpCompactData)
+	router.HandleFunc("/data/sync", node.httpSyncData)
 	router.HandleFunc("/status", node.httpStatus)
 	router.HandleFunc("/status/{state}", node.httpStatusSet)
 	router.HandleFunc("/config/dir", node.httpConfigDir)

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -86,6 +86,7 @@ func main() {
 	router.HandleFunc("/data/merge/{peerId}", node.httpMergeData)
 	router.HandleFunc("/data/keys", node.httpDataKeys)
 	router.HandleFunc("/data/gc", node.httpGCData)
+	router.HandleFunc("/data/compact", node.httpCompactData)
 	router.HandleFunc("/status", node.httpStatus)
 	router.HandleFunc("/status/{state}", node.httpStatusSet)
 	router.HandleFunc("/config/dir", node.httpConfigDir)

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -84,6 +84,7 @@ func main() {
 	router.HandleFunc("/data/put", node.httpPutData)
 	router.HandleFunc("/data/get/{objectId}", node.httpGetData)
 	router.HandleFunc("/data/merge/{peerId}", node.httpMergeData)
+	router.HandleFunc("/data/gc", node.httpGCData)
 	router.HandleFunc("/status", node.httpStatus)
 	router.HandleFunc("/status/{state}", node.httpStatusSet)
 	router.HandleFunc("/config/dir", node.httpConfigDir)

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -84,6 +84,7 @@ func main() {
 	router.HandleFunc("/data/put", node.httpPutData)
 	router.HandleFunc("/data/get/{objectId}", node.httpGetData)
 	router.HandleFunc("/data/merge/{peerId}", node.httpMergeData)
+	router.HandleFunc("/data/keys", node.httpDataKeys)
 	router.HandleFunc("/data/gc", node.httpGCData)
 	router.HandleFunc("/status", node.httpStatus)
 	router.HandleFunc("/status/{state}", node.httpStatusSet)

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -66,6 +66,7 @@ type Datastore interface {
 	Get(Key) ([]byte, error)
 	Delete(Key) error
 	IterKeys(ctx context.Context) <-chan Key
+	Compact()
 	Close()
 }
 

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -65,7 +65,7 @@ type Datastore interface {
 	Has(Key) (bool, error)
 	Get(Key) ([]byte, error)
 	Delete(Key) error
-	IterKeys(ctx context.Context) <-chan Key
+	IterKeys(ctx context.Context) (<-chan Key, error)
 	Sync() error
 	Compact()
 	Close()

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -65,6 +65,7 @@ type Datastore interface {
 	Has(Key) (bool, error)
 	Get(Key) ([]byte, error)
 	Delete(Key) error
+	IterKeys(ctx context.Context) <-chan Key
 	Close()
 }
 

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -66,6 +66,7 @@ type Datastore interface {
 	Get(Key) ([]byte, error)
 	Delete(Key) error
 	IterKeys(ctx context.Context) <-chan Key
+	Sync() error
 	Compact()
 	Close()
 }


### PR DESCRIPTION
Closes #64 
Implements datastore garbage collection with direct iteration.

Implementation Notes:
- datastore iterators require flushing the db to work reliably
- a temporary db is used for storing the live object index
- `/data/compact` api endpoint for manual compaction; gc triggers it if it deletes any objects, but it's also useful on its own right
- `/data/sync` api endpoint: the WAL seems to be using some dark space in linux/ext4 (not visible in ls, but visible in du) following merges, but it seems to be bounded by the log size. Flushing the datastore through the endpoint immediately reclaims this space,
- `/data/keys` api endpoint which dumps the keys for all objects in the datastore.

Example:
```
$ du --si /mnt/ssd2/data/
193k    /mnt/ssd2/data/
$ mcclient status online
status set to online
$ time mcclient merge QmeiY2eHMwK92Zt6X4kUUC3MsjMmVb2VnGZ17DhnhRPCEQ "SELECT * FROM images.dpla LIMIT 1000000"
merged 1000000 statements and 1000001 objects

real    6m48.171s
user    0m0.345s
sys     0m0.033s
$ du --si /mnt/ssd2/data/
867M    /mnt/ssd2/data/
$ time mcclient delete "DELETE FROM images.dpla"  
Deleted 1000000 statements

real    1m2.060s
user    0m0.332s
sys     0m0.041s
$ mcclient status offline
status set to offline
$ time curl http://127.0.0.1:9002/data/gc
1000001

real    0m57.923s
user    0m0.000s
sys     0m0.008s
$ du --si /mnt/ssd2/data/
193k    /mnt/ssd2/data/
```