### PR TITLE
Fix crash from uninitialized auth map set

### DIFF
--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -451,6 +451,9 @@ func (auth *PeerAuth) getRules(pid p2p_peer.ID) []string {
 
 func (auth *PeerAuth) setRules(pid p2p_peer.ID, rules []string) {
 	auth.mx.Lock()
+	if auth.peers == nil {
+		auth.peers = make(map[p2p_peer.ID][]string)
+	}
 	auth.peers[pid] = rules
 	auth.mx.Unlock()
 }


### PR DESCRIPTION
Closes #93 
The auth map is normally initialized by loadConfig, but in the absence of a config file it will be left uninitialized.
This creates the map on demand if it's not initialized.
