### PR TITLE
Use fork of gorocksdb to avoid build error

### DIFF
--- a/mcnode/ds.go
+++ b/mcnode/ds.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	mc "github.com/mediachain/concat/mc"
-	rocksdb "github.com/tecbot/gorocksdb"
+	rocksdb "github.com/mediachain/gorocksdb"
 	"log"
 	"os"
 	"path"

--- a/setup.sh
+++ b/setup.sh
@@ -15,6 +15,6 @@ echo "Installing unvendored deps"
 go get github.com/gorilla/mux github.com/mattn/go-sqlite3 github.com/mitchellh/go-homedir || die
 
 echo "Installing gorocksdb; this can take a while!"
-go get -tags=embed github.com/tecbot/gorocksdb || die
+go get -tags=embed github.com/mediachain/gorocksdb || die
 
 echo "DONE"


### PR DESCRIPTION
A commit to gorocksdb broke the embedded build:
https://github.com/tecbot/gorocksdb/issues/71

This points us at a mediachain fork with the problematic commit
reverted.  We can either keep our fork in sync with the upstream,
or switch back once they incorporate the fix.