### PR TITLE
Net connections and small fixes

### DIFF
--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -84,6 +84,15 @@ func (node *Node) httpNetAddr(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// GET /net/conns
+// Returns all active peer connections
+func (node *Node) httpNetConns(w http.ResponseWriter, r *http.Request) {
+	peers := node.netConns()
+	for _, peer := range peers {
+		fmt.Fprintln(w, mc.FormatHandle(peer))
+	}
+}
+
 // GET /net/lookup/{peerId}
 // Looks up a peer in the network
 func (node *Node) httpNetLookup(w http.ResponseWriter, r *http.Request) {

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -84,6 +84,23 @@ func (node *Node) httpNetAddr(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// GET /net/addr/{peerId}
+// Returns all peer addrs in the local cache
+func (node *Node) httpNetPeerAddr(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	peerId := vars["peerId"]
+	pid, err := p2p_peer.IDB58Decode(peerId)
+	if err != nil {
+		apiError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	addrs := node.netPeerAddrs(pid)
+	for _, addr := range addrs {
+		fmt.Fprintln(w, addr.String())
+	}
+}
+
 // GET /net/conns
 // Returns all active peer connections
 func (node *Node) httpNetConns(w http.ResponseWriter, r *http.Request) {

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -97,6 +97,7 @@ func main() {
 	router.HandleFunc("/auth/{peerId}", node.httpAuthPeer)
 	router.HandleFunc("/dir/list", node.httpDirList)
 	router.HandleFunc("/net/addr", node.httpNetAddr)
+	router.HandleFunc("/net/addr/{peerId}", node.httpNetPeerAddr)
 	router.HandleFunc("/net/conns", node.httpNetConns)
 	router.HandleFunc("/net/lookup/{peerId}", node.httpNetLookup)
 	router.HandleFunc("/shutdown", node.httpShutdown)

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -97,6 +97,7 @@ func main() {
 	router.HandleFunc("/auth/{peerId}", node.httpAuthPeer)
 	router.HandleFunc("/dir/list", node.httpDirList)
 	router.HandleFunc("/net/addr", node.httpNetAddr)
+	router.HandleFunc("/net/conns", node.httpNetConns)
 	router.HandleFunc("/net/lookup/{peerId}", node.httpNetLookup)
 	router.HandleFunc("/shutdown", node.httpShutdown)
 

--- a/mcnode/net.go
+++ b/mcnode/net.go
@@ -270,6 +270,15 @@ func (node *Node) natAddr() multiaddr.Multiaddr {
 	return addr
 }
 
+func (node *Node) netPeerAddrs(pid p2p_peer.ID) []multiaddr.Multiaddr {
+	if node.status == StatusOffline {
+		return nil
+	}
+
+	pinfo := node.host.Peerstore().PeerInfo(pid)
+	return pinfo.Addrs
+}
+
 func (node *Node) netConns() []p2p_pstore.PeerInfo {
 	if node.status == StatusOffline {
 		return nil

--- a/mcnode/net.go
+++ b/mcnode/net.go
@@ -270,6 +270,21 @@ func (node *Node) natAddr() multiaddr.Multiaddr {
 	return addr
 }
 
+func (node *Node) netConns() []p2p_pstore.PeerInfo {
+	if node.status == StatusOffline {
+		return nil
+	}
+
+	conns := node.host.Network().Conns()
+	peers := make([]p2p_pstore.PeerInfo, len(conns))
+	for x, conn := range conns {
+		peers[x].ID = conn.RemotePeer()
+		peers[x].Addrs = []multiaddr.Multiaddr{conn.RemoteMultiaddr()}
+	}
+
+	return peers
+}
+
 // Connectivity
 func (node *Node) doConnect(ctx context.Context, pid p2p_peer.ID) error {
 	if node.status == StatusOffline {

--- a/mcnode/net.go
+++ b/mcnode/net.go
@@ -311,7 +311,7 @@ func (node *Node) doConnect(ctx context.Context, pid p2p_peer.ID) error {
 func (node *Node) doLookup(ctx context.Context, pid p2p_peer.ID) (pinfo p2p_pstore.PeerInfo, err error) {
 	pinfo, err = node.doLookupImpl(ctx, pid)
 	if err == nil {
-		node.host.Peerstore().AddAddrs(pid, pinfo.Addrs, p2p_pstore.AddressTTL)
+		node.host.Peerstore().AddAddrs(pid, pinfo.Addrs, p2p_pstore.ProviderAddrTTL)
 	}
 
 	return


### PR DESCRIPTION
- Adds `/net/conns` api hook for retrieving all actively connected peers, formatted as multiaddr handles.
- Adds `/net/addr/{peerId}` api hook for retrieving known/cached peer addresses
- Fixes FormatHandle to format canonically in the naked id case.
- Changes the lookup cache TTL to 10min.

Example:
```
# no connections, node just booted
$ curl http://localhost:9002/net/conns

# go online
$ mcclient status online
status set to online

# bootstrap connections
$ curl http://localhost:9002/net/conns
/ip4/104.236.76.40/tcp/4001/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64
/ip4/128.199.219.111/tcp/4001/p2p/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu
/ip4/104.236.179.241/tcp/4001/p2p/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM
/ip4/178.62.158.247/tcp/4001/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd

# let's do a DHT lookup
$ mcclient lookupPeer QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp
Looking up peer:  QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp
/ip4/54.242.130.109/tcp/9001
/ip4/10.10.1.191/tcp/9001

# it's now cached
$ curl http://localhost:9002/net/addr/QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp
/ip4/54.242.130.109/tcp/9001
/ip4/10.10.1.191/tcp/9001

# and we have a bunch of new peers from the DHT lookup
$ curl http://localhost:9002/net/conns
/ip4/82.29.1.58/tcp/4001/p2p/QmYHk2VWWNAbc4zU5oyemfadBYMtNmutqXHjSDV8hm5E7g
/ip4/139.162.191.34/tcp/4001/p2p/QmR8oT8pBQ4jmy4UAM3yKy6xT3DipH9H23Dykx7k7uUkyJ
/ip4/5.9.150.40/tcp/4737/p2p/QmaeXrsLHWm4gbjyEUJ4NtPsF3d36mXVzY5eTBQHLdMQ19
/ip4/159.203.77.184/tcp/4001/p2p/QmeLGqhi5dFBpxD4xuzAWWcoip69i5SaneXL9Jb83sxSXo
/ip4/52.174.148.81/tcp/4001/p2p/QmcqEFHP3MV3CMoWCXtGYPBpDbWwNx8cRXssbwAKk7347m
/ip4/155.4.88.35/tcp/4001/p2p/QmVF1Z9qaQQmB6njektrPwTfdxccbDXeeZDeaBS44H4Mgs
/ip4/159.203.219.127/tcp/20069/p2p/QmTfY9nWEgSWgYRmzzXnhc5R9TSTKH1BZ7XQjoTfncez4w
/ip4/65.19.134.246/tcp/4001/p2p/QmNfnZ8SCs3jAtNPc8kf3WJqJqSoX7wsX7VqkLdEYMao4u
/ip4/204.44.93.14/tcp/4001/p2p/QmPfnToXqQUt9pWF7AyDgXh9r4FsF4gsy9zAAhfrZN1kza
/ip4/128.199.219.111/tcp/4001/p2p/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu
/ip4/178.62.158.247/tcp/4001/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd
/ip4/52.7.126.237/tcp/9000/p2p/QmSdJVceFki4rDbcSrW7JTJZgU9so25Ko7oKHE97mGmkU6
/ip4/163.172.45.41/tcp/4001/p2p/QmbGJgRuT3FNZiCuuqQoUcx6tZJwYqKf4dvB6mvnBCW4pH
/ip4/5.9.59.34/tcp/4001/p2p/QmRv1GNseNP1krEwHDjaQMeQVJy41879QcDwpJVhY8SWve
/ip4/104.236.76.40/tcp/4001/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64
/ip4/37.187.116.23/tcp/4001/p2p/QmbqE6UfCJaXST3i65zbr649s8cJCUoP9m3UFUrXcNgeDn
/ip4/52.208.14.111/tcp/4001/p2p/QmYfXkBFBfo3PhGdSyMLjdNFBwesxNcREVxMVySMVGUqfC
/ip4/66.65.113.249/tcp/4001/p2p/QmZmY8n6DLdFhQhDGDjxENzcufYCfUMHpNG8oTpGr9WZ4q
/ip4/104.236.176.52/tcp/4001/p2p/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z
/ip4/104.236.179.241/tcp/4001/p2p/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM
/ip4/45.55.92.82/tcp/4001/p2p/QmaB5JnXMKK9D3JFNwVGhSvGLFgRuhgvK21THtxWeb5R38
/ip4/80.70.228.55/tcp/4001/p2p/QmdmNSZii93cyXTXRnRq1pnibYAza8LueqrPsmao5j4R7J
/ip4/66.246.138.156/tcp/4001/p2p/QmYp4TeCurXrhsxnzt5wqLqqUz8ZRg5zsc7GuUrUSDtwzP
/ip4/139.162.191.65/tcp/4001/p2p/QmPeCS6UkPMY3DyuXVcLt8DfvTuWCdpA86HrtdkYoV2pe2
```