### PR TITLE
Datastore batch object retrieval api

### DIFF
--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -595,7 +595,7 @@ func (node *Node) httpGetData(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// GET /data/get/
+// POST /data/get
 // Retrieves a batch of data objects from the datastore
 func (node *Node) httpGetDataBatch(w http.ResponseWriter, r *http.Request) {
 	enc := json.NewEncoder(w)

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -82,6 +82,7 @@ func main() {
 	router.HandleFunc("/push/{peerId}", node.httpPush)
 	router.HandleFunc("/delete", node.httpDelete)
 	router.HandleFunc("/data/put", node.httpPutData)
+	router.HandleFunc("/data/get", node.httpGetDataBatch)
 	router.HandleFunc("/data/get/{objectId}", node.httpGetData)
 	router.HandleFunc("/data/merge/{peerId}", node.httpMergeData)
 	router.HandleFunc("/data/keys", node.httpDataKeys)


### PR DESCRIPTION
Implements `/data/get` for batch object retrieval
Closes #91 

The endpoint accepts a newline separated list of object keys, and returns a stream of data objects.
If a key is not stored in the datastore, then the returned data object will have a null data field.
If an errors occurs (eg a bad key or a datastore error), then the stream ends with a StreamError.

Example:
```
$ cat /tmp/some-keys
QmYGRQYmWC3BAtTAi88mFb7GVeFsUKGM4nm25SBUB9vfc9
QmeFJSTPKSEiNqebxZvYcduWH8UBmxqNq724gHEQnxV5D1

$ curl -i --data-binary "@/tmp/some-keys" http://localhost:9002/data/get
{"data":"pmckc2NoZW1heCdodHRwOi8vanNvbi1zY2hlbWEub3JnL2RyYWZ0LTA0L3NjaGVtYSNrZGVzY3JpcHRpb254Jk1lZGlhY2hhaW4gTGFicyBpbmRleGVyIGltYWdlIG1ldGFkYXRhZHNlbGakZnZlbmRvcnVpby5tZWRpYWNoYWluLmluZGV4ZXJkbmFtZWVpbWFnZWZmb3JtYXRqanNvbnNjaGVtYWd2ZXJzaW9uZTEtMC0wZHR5cGVmb2JqZWN0anByb3BlcnRpZXO4JWtvcmllbnRhdGlvbqFkdHlwZYJmc3RyaW5nZG51bGxrY2FtZXJhX2V4aWahZHR5cGWCZm9iamVjdGRudWxsZm9yaWdpbqFkdHlwZYJmc3RyaW5nZG51bGxrYXR0cmlidXRpb26hZHR5cGWDZnN0cmluZ2RudWxsZWFycmF5a2Rlc2NyaXB0aW9uoWR0eXBlgmZzdHJpbmdkbnVsbGtzb3VyY2VfdGFnc6JkdHlwZWVhcnJheWVpdGVtc6FkdHlwZWZzdHJpbmdudHJhbnNpZW50X2luZm+hZHR5cGVmb2JqZWN0ZXRpdGxlomR0eXBlg2ZzdHJpbmdkbnVsbGVhcnJheWVpdGVtc6FkdHlwZWZzdHJpbmdsYXNwZWN0X3JhdGlvoWR0eXBlgmZudW1iZXJkbnVsbGpkZWR1cGVfaHNooWR0eXBlZnN0cmluZ25zb3VyY2VfZGF0YXNldKFkdHlwZWZzdHJpbmdrYXJ0aXN0X25hbWWhZHR5cGWCZnN0cmluZ2RudWxsaGtleXdvcmRzomR0eXBlZWFycmF5ZWl0ZW1zoWpwcm9wZXJ0aWVzoGluYXRpdmVfaWShZHR5cGVmc3RyaW5nbGxpY2Vuc2VfdGFnc6JkdHlwZWVhcnJheWVpdGVtc6FqcHJvcGVydGllc6BrbGljZW5zZV91cmyhZHR5cGWCZnN0cmluZ2RudWxsZXNpemVzo2R0eXBlZWFycmF5a3VuaXF1ZUl0ZW1z9WVpdGVtc6FqcHJvcGVydGllc6Nld2lkdGihZHR5cGWCZm51bWJlcmRudWxsbGNvbnRlbnRfdHlwZaFkdHlwZYJmc3RyaW5nZG51bGxmaGVpZ2h0oWR0eXBlZm51bWJlcmhsaWNlbnNlc6NkdHlwZWVhcnJheWt1bmlxdWVJdGVtc/VlaXRlbXOhanByb3BlcnRpZXOjZG5hbWWhZHR5cGWCZnN0cmluZ2RudWxsaW5hbWVfbG9uZ6FkdHlwZYJmc3RyaW5nZG51bGxnZGV0YWlsc6FkdHlwZYNmc3RyaW5nZG51bGxlYXJyYXltZGF0ZV9jYXB0dXJlZKFkdHlwZYJmc3RyaW5nZG51bGxsZGF0ZV9jcmVhdGVkoWR0eXBlgmZzdHJpbmdkbnVsbHZkYXRlX2NyZWF0ZWRfYXRfc291cmNloWR0eXBlgmZzdHJpbmdkbnVsbHVkYXRlX2NyZWF0ZWRfb3JpZ2luYWyhZHR5cGWCZnN0cmluZ2RudWxsc2RhdGVfc291cmNlX3ZlcnNpb26hZHR5cGWCZnN0cmluZ2RudWxsbGFydGlzdF9uYW1lc6JkdHlwZYJlYXJyYXlkbnVsbGVpdGVtc6FkdHlwZYNmc3RyaW5nZWFycmF5ZG51bGxqdXJsX2RpcmVjdKJkdHlwZYJmb2JqZWN0ZG51bGxqcHJvcGVydGllc6FjdXJsoWR0eXBlZnN0cmluZ3BuYXRpdmVfc291cmNlX2lkoWR0eXBlgmZzdHJpbmdkbnVsbGx1cmxfc2hvd25fYXSiZHR5cGWCZm9iamVjdGRudWxsanByb3BlcnRpZXOhY3VybKFkdHlwZWZzdHJpbmdobG9jYXRpb26hZHR5cGWCZm9iamVjdGRudWxsbGxpY2Vuc2VfbmFtZaFkdHlwZYJmc3RyaW5nZG51bGxxbGljZW5zZV9uYW1lX2xvbmehZHR5cGWCZnN0cmluZ2RudWxsc2Flc191bnNwbGFzaF9vdXRfdjGhZHR5cGWCZm9iamVjdGRudWxscWRlcml2ZWRfcXVhbGl0aWVzoWR0eXBlgmZvYmplY3RkbnVsbG5wcm92aWRlcnNfbGlzdKJkdHlwZYJlYXJyYXlkbnVsbGVpdGVtc6JkdHlwZWZvYmplY3RqcHJvcGVydGllc6FkbmFtZaFkdHlwZWZzdHJpbmdtb3JkZXJfbW9kZWxfM6FkdHlwZYJmc3RyaW5nZG51bGxkeGFubqJkdHlwZYJlYXJyYXlkbnVsbGVpdGVtc6FkdHlwZWZzdHJpbmdkbnNmd6FkdHlwZYJnYm9vbGVhbmRudWxsZnNvdXJjZaNkdHlwZYJmb2JqZWN0ZG51bGxqcHJvcGVydGllc6JjdXJsoWR0eXBlZnN0cmluZ2RuYW1loWR0eXBlZnN0cmluZ2hyZXF1aXJlZIJjdXJsZG5hbWV0YWRkaXRpb25hbFByb3BlcnRpZXP0"}
{"data":"omZzY2hlbWGhYS94LlFtWUdSUVltV0MzQkF0VEFpODhtRmI3R1ZlRnNVS0dNNG5tMjVTQlVCOXZmYzlkZGF0YbgZbGFydGlzdF9uYW1lc4GBc01lcmVkaXRoIEwuIENsYXVzZW5sYXNwZWN0X3JhdGlv+z/m7u7u7u7va2F0dHJpYnV0aW9ugaFkbmFtZXNNZXJlZGl0aCBMLiBDbGF1c2Vua2NhbWVyYV9leGlmoG1kYXRlX2NhcHR1cmVk9nZkYXRlX2NyZWF0ZWRfYXRfc291cmNl9nVkYXRlX2NyZWF0ZWRfb3JpZ2luYWz2c2RhdGVfc291cmNlX3ZlcnNpb272amRlZHVwZV9oc2hwM2ZkZmVmZTBmODM4MTQwM3FkZXJpdmVkX3F1YWxpdGllc6ZmY29sb3Jz9mxnZW5lcmFsX3R5cGX2amhhc19wZW9wbGX2Zm1lZGl1bfZucHJlZGljdGVkX3RhZ3P2a3RpbWVfcGVyaW9k9mtkZXNjcmlwdGlvbnZDbGF1c2VuL0Rvbm5lbGx5IEhvdXNlaGtleXdvcmRzgGhsaWNlbnNlc4GhZ2RldGFpbHNzTWVyZWRpdGggTC4gQ2xhdXNlbmhsb2NhdGlvbqJnbGF0X2xvbvZqcGxhY2VfbmFtZYBpbmF0aXZlX2lkeDxkcGxhX2h0dHA6Ly9kcC5sYS9hcGkvaXRlbXMvMWZmNmIzNjE3NDQyNjAyNjg0N2M4ZjhjYTIxNmZmYTlrb3JpZW50YXRpb272bnByb3ZpZGVyc19saXN0gqFkbmFtZWRkcGxhoWRuYW1leBhVbml2ZXJzaXR5IG9mIFdhc2hpbmd0b25lc2l6ZXOBpmVieXRlc/ZsY29udGVudF90eXBlamltYWdlL2pwZWdjZHBp9mZoZWlnaHQYeGx1cmlfZXh0ZXJuYWx4Umh0dHA6Ly9jZG0xNjc4Ni5jb250ZW50ZG0ub2NsYy5vcmcvdXRpbHMvZ2V0dGh1bWJuYWlsL2NvbGxlY3Rpb24vYnVpbGRpbmdzL2lkLzc5ODdld2lkdGgYVmZzb3VyY2WiZG5hbWVkZHBsYWN1cmxuaHR0cHM6Ly9kcC5sYS9uc291cmNlX2RhdGFzZXRkZHBsYWtzb3VyY2VfdGFnc4FlZHAubGFldGl0bGWBdkNsYXVzZW4vRG9ubmVsbHkgSG91c2VudHJhbnNpZW50X2luZm+iZWxpa2Vz9nJzY29yZV9ob3RuZXNzdmlld3P2anVybF9kaXJlY3ShY3VybHhSaHR0cDovL2NkbTE2Nzg2LmNvbnRlbnRkbS5vY2xjLm9yZy91dGlscy9nZXR0aHVtYm5haWwvY29sbGVjdGlvbi9idWlsZGluZ3MvaWQvNzk4N2x1cmxfc2hvd25fYXShY3VybHhHaHR0cDovL2NkbTE2Nzg2LmNvbnRlbnRkbS5vY2xjLm9yZy9jZG0vcmVmL2NvbGxlY3Rpb24vYnVpbGRpbmdzL2lkLzc5ODc="}

$ cat /tmp/non-existent-key 
QmeBkfxcaBfA9pvzivRwhF2PM7sXpp4HHQbp7jfTkRCWEa

$ curl --data-binary "@/tmp/non-existent-key" http://localhost:9002/data/get
{"data":null}

$ cat /tmp/malformed-key
NotAMultihash

vyzo@carbon golang $ curl -i --data-binary "@/tmp/malformed-key" http://localhost:9002/data/get
{"error":"multihash too short. must be \u003e 3 bytes"}
```