### PR TITLE
Multiple directory support in mcnode

### DIFF
--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	mux "github.com/gorilla/mux"
 	p2p_peer "github.com/libp2p/go-libp2p-peer"
+	p2p_pstore "github.com/libp2p/go-libp2p-peerstore"
 	mc "github.com/mediachain/concat/mc"
 	mcq "github.com/mediachain/concat/mc/query"
 	pb "github.com/mediachain/concat/proto"
@@ -851,31 +852,26 @@ func (node *Node) httpConfigDir(w http.ResponseWriter, r *http.Request) {
 }
 
 func (node *Node) httpConfigDirGet(w http.ResponseWriter, r *http.Request) {
-	if node.dir != nil {
-		fmt.Fprintln(w, mc.FormatHandle(*node.dir))
-	} else {
-		fmt.Fprintln(w, "nil")
+	for _, dir := range node.dir {
+		fmt.Fprintln(w, mc.FormatHandle(dir))
 	}
 }
 
 func (node *Node) httpConfigDirSet(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		log.Printf("http/config/dir: Error reading request body: %s", err.Error())
-		return
+	dirs := make([]p2p_pstore.PeerInfo, 0)
+	scanner := bufio.NewScanner(r.Body)
+	for scanner.Scan() {
+		pinfo, err := mc.ParseHandle(scanner.Text())
+		if err != nil {
+			apiError(w, http.StatusBadRequest, err)
+			return
+		}
+		dirs = append(dirs, pinfo)
 	}
 
-	handle := strings.TrimSpace(string(body))
-	pinfo, err := mc.ParseHandle(handle)
+	node.dir = dirs
 
-	if err != nil {
-		apiError(w, http.StatusBadRequest, err)
-		return
-	}
-
-	node.dir = &pinfo
-
-	err = node.saveConfig()
+	err := node.saveConfig()
 	if err != nil {
 		apiError(w, http.StatusInternalServerError, err)
 		return

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -177,7 +177,7 @@ func (node *Node) httpDirListImpl(w http.ResponseWriter, r *http.Request, inclSe
 	vars := mux.Vars(r)
 	ns := vars["namespace"]
 
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
 	peers, err := node.doDirList(ctx, ns)
@@ -198,7 +198,7 @@ func (node *Node) httpDirListImpl(w http.ResponseWriter, r *http.Request, inclSe
 // GET /dir/listns
 // List namespaces known to the directory
 func (node *Node) httpDirListNS(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
 	nss, err := node.doDirListNS(ctx)

--- a/mcnode/net.go
+++ b/mcnode/net.go
@@ -368,12 +368,17 @@ func (node *Node) doLookupImpl(ctx context.Context, pid p2p_peer.ID) (pinfo p2p_
 		return pinfo, NodeOffline
 	}
 
-	if node.dir == nil {
+	var dirctx context.Context
+	var cancel context.CancelFunc
+
+	if len(node.dir) == 0 {
 		goto lookup_dht
 	}
 
-	// TODO: partial timeout for dir lookup (don't use all the available time)
-	pinfo, err = node.doDirLookup(ctx, pid)
+	dirctx, cancel = context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	pinfo, err = node.doDirLookup(dirctx, pid)
 	if err == nil {
 		return
 	}

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -108,6 +108,7 @@ var (
 	BadRuleset       = errors.New("Bad auth ruleset; unexpected object")
 	NodeOffline      = errors.New("Node is offline")
 	NoDirectory      = errors.New("No directory server")
+	DirectoryError   = errors.New("Directory error")
 	UnknownPeer      = errors.New("Unknown peer")
 	IllegalState     = errors.New("Illegal node state")
 )


### PR DESCRIPTION
Closes #77 

Implementation Details:
- dir configuration takes a list of handles, with auto-migration of old config files (on first config change).
- dir lookups start in parallel, with first response winning.
- dir listings happen in parallel and aggregate results from both peers.

Some changes to timeouts:
- sets dir listing operations to 10s, so that we can get results timely even if some dirs are badly failed.
- similarly sets an internal 10s timeout for directory lookup, so that we can fallback to the dht in timely fashion.

