### PR TITLE
Reduce directory lookup timeout

### DIFF
--- a/mcnode/net.go
+++ b/mcnode/net.go
@@ -375,7 +375,7 @@ func (node *Node) doLookupImpl(ctx context.Context, pid p2p_peer.ID) (pinfo p2p_
 		goto lookup_dht
 	}
 
-	dirctx, cancel = context.WithTimeout(ctx, 10*time.Second)
+	dirctx, cancel = context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	pinfo, err = node.doDirLookup(dirctx, pid)


### PR DESCRIPTION
this tunes the directory lookup timeout to 5s, so that a single directory failure (or libp2p acting mysterious and failing to connect) will not hold up a dht lookup for a full 10s in the case of unregistered nodes.

Could be even lower, maybe 2-3s, but I would rather be conservative with this; 5s is a potentially slow lookup from the dht, but not intolerably so.