### PR TITLE
Deduplicate wkis in mcq.StatementRefs for compound statements

### DIFF
--- a/mc/query/stmt.go
+++ b/mc/query/stmt.go
@@ -10,58 +10,65 @@ func StatementRefs(stmt *pb.Statement) []string {
 		return body.Simple.Refs
 
 	case *pb.StatementBody_Compound:
-		stmts := body.Compound.Body
-		count := 0
-		for _, stmt := range stmts {
-			count += len(stmt.Refs)
-		}
-		refs := make([]string, 0, count)
-		for _, stmt := range stmts {
-			refs = append(refs, stmt.Refs...)
-		}
-		return refs
+		refs := makeStatementRefSet()
+		refs.mergeCompound(body.Compound)
+		return refs.toList()
 
 	case *pb.StatementBody_Envelope:
-		stmts := body.Envelope.Body
-		count := 0
-		for _, stmt := range stmts {
-			count += countStatementRefs(stmt)
-		}
-		refs := make([]string, 0, count)
-		for _, stmt := range stmts {
-			refs = append(refs, StatementRefs(stmt)...)
-		}
-		return refs
+		refs := makeStatementRefSet()
+		refs.mergeEnvelope(body.Envelope)
+		return refs.toList()
 
 	default:
 		return nil
 	}
 }
 
-func countStatementRefs(stmt *pb.Statement) int {
+type StatementRefSet map[string]bool
+
+func makeStatementRefSet() StatementRefSet {
+	return StatementRefSet(make(map[string]bool))
+}
+
+func (refs StatementRefSet) mergeStatement(stmt *pb.Statement) {
 	switch body := stmt.Body.Body.(type) {
 	case *pb.StatementBody_Simple:
-		return len(body.Simple.Refs)
+		refs.mergeSimple(body.Simple)
 
 	case *pb.StatementBody_Compound:
-		stmts := body.Compound.Body
-		count := 0
-		for _, stmt := range stmts {
-			count += len(stmt.Refs)
-		}
-		return count
+		refs.mergeCompound(body.Compound)
 
 	case *pb.StatementBody_Envelope:
-		stmts := body.Envelope.Body
-		count := 0
-		for _, stmt := range stmts {
-			count += countStatementRefs(stmt)
-		}
-		return count
-
-	default:
-		return 0
+		refs.mergeEnvelope(body.Envelope)
 	}
+}
+
+func (refs StatementRefSet) mergeSimple(stmt *pb.SimpleStatement) {
+	for _, wki := range stmt.Refs {
+		refs[wki] = true
+	}
+}
+
+func (refs StatementRefSet) mergeCompound(stmt *pb.CompoundStatement) {
+	for _, xstmt := range stmt.Body {
+		refs.mergeSimple(xstmt)
+	}
+}
+
+func (refs StatementRefSet) mergeEnvelope(stmt *pb.EnvelopeStatement) {
+	for _, xstmt := range stmt.Body {
+		refs.mergeStatement(xstmt)
+	}
+}
+
+func (refs StatementRefSet) toList() []string {
+	lst := make([]string, len(refs))
+	x := 0
+	for wki, _ := range refs {
+		lst[x] = wki
+		x++
+	}
+	return lst
 }
 
 func StatementSource(stmt *pb.Statement) string {

--- a/mc/query/stmt.go
+++ b/mc/query/stmt.go
@@ -5,23 +5,9 @@ import (
 )
 
 func StatementRefs(stmt *pb.Statement) []string {
-	switch body := stmt.Body.Body.(type) {
-	case *pb.StatementBody_Simple:
-		return body.Simple.Refs
-
-	case *pb.StatementBody_Compound:
-		refs := makeStatementRefSet()
-		refs.mergeCompound(body.Compound)
-		return refs.toList()
-
-	case *pb.StatementBody_Envelope:
-		refs := makeStatementRefSet()
-		refs.mergeEnvelope(body.Envelope)
-		return refs.toList()
-
-	default:
-		return nil
-	}
+	refs := makeStatementRefSet()
+	refs.mergeStatement(stmt)
+	return refs.toList()
 }
 
 type StatementRefSet map[string]bool


### PR DESCRIPTION
This fixes a subtle issue with duplicate wkis in compound statements: 
It is possible for a compound statement to include simple statements which refer to the same wki, which would be included multiple times in the list returned by `mcq.StatementRef`.
As a result, the same statement would be mapped to the same wki multiple times in the Refs table. 
This would create garbage in the db and have the unfortunate side effect of having the same statement appear multiple times in a query result set even when querying for a single wki.

The PR fixes this by constructing a set for compound statements, which deduplicates the wkis.
Measurements indicate no performance penalty for compound statement processing.

PS: Also added dedup for simple statements, to protect from faulty publishers who don't dedup their references.
Performance degradation for simple statements is also neglible.