### PR TITLE
Return reference set from mcq.StatementRefs

### DIFF
--- a/mc/query/eval.go
+++ b/mc/query/eval.go
@@ -129,7 +129,7 @@ var rangeCriteriaFilterSelect = map[string]RangeCriteriaFilterSelect{
 	"counter":   counterCriteriaFilter}
 
 func wkiCriteriaFilter(stmt *pb.Statement) []string {
-	return StatementRefs(stmt)
+	return StatementRefs(stmt).List()
 }
 
 func indexCriteriaContains(keys []string, val string) bool {

--- a/mc/query/query_test.go
+++ b/mc/query/query_test.go
@@ -1243,7 +1243,7 @@ func insertStmt(db *sql.DB, stmt *pb.Statement) error {
 	// source = publisher only for simple statements
 	_, err = db.Exec("INSERT INTO Envelope VALUES (NULL,?, ?, ?, ?, ?)", stmt.Id, stmt.Namespace, stmt.Publisher, stmt.Publisher, stmt.Timestamp)
 
-	for _, wki := range StatementRefs(stmt) {
+	for wki, _ := range StatementRefs(stmt) {
 		_, err = db.Exec("INSERT INTO Refs VALUES (?, ?)", stmt.Id, wki)
 		if err != nil {
 			return err

--- a/mc/query/stmt.go
+++ b/mc/query/stmt.go
@@ -4,10 +4,10 @@ import (
 	pb "github.com/mediachain/concat/proto"
 )
 
-func StatementRefs(stmt *pb.Statement) []string {
+func StatementRefs(stmt *pb.Statement) StatementRefSet {
 	refs := makeStatementRefSet()
 	refs.mergeStatement(stmt)
-	return refs.toList()
+	return refs
 }
 
 type StatementRefSet map[string]bool
@@ -47,7 +47,7 @@ func (refs StatementRefSet) mergeEnvelope(stmt *pb.EnvelopeStatement) {
 	}
 }
 
-func (refs StatementRefSet) toList() []string {
+func (refs StatementRefSet) List() []string {
 	lst := make([]string, len(refs))
 	x := 0
 	for wki, _ := range refs {

--- a/mcnode/db.go
+++ b/mcnode/db.go
@@ -53,7 +53,7 @@ func (sdb *SQLDB) Put(stmt *pb.Statement) error {
 	}
 
 	xstmt = tx.Stmt(sdb.insertStmtRefs)
-	for _, wki := range mcq.StatementRefs(stmt) {
+	for wki, _ := range mcq.StatementRefs(stmt) {
 		_, err = xstmt.Exec(stmt.Id, wki)
 		if err != nil {
 			tx.Rollback()
@@ -96,7 +96,7 @@ func (sdb *SQLDB) PutBatch(stmts []*pb.Statement) error {
 			return err
 		}
 
-		for _, wki := range mcq.StatementRefs(stmt) {
+		for wki, _ := range mcq.StatementRefs(stmt) {
 			_, err = insertRefs.Exec(stmt.Id, wki)
 			if err != nil {
 				tx.Rollback()
@@ -470,7 +470,7 @@ func (sdb *SQLiteDB) MergeBatch(stmts []*pb.Statement) (count int, err error) {
 			return 0, err
 		}
 
-		for _, wki := range mcq.StatementRefs(stmt) {
+		for wki, _ := range mcq.StatementRefs(stmt) {
 			_, err = insertRefs.Exec(stmt.Id, wki)
 			if err != nil {
 				tx.Rollback()


### PR DESCRIPTION
Follow up to #107 

Now that the simple statements are also deduplicated, there is nothing to gain from an interface that constructs a list from an intermediate set.
This changes `mcq.StatementRefs` to return the set directly