### PR TITLE
Parallelize dht and dir lookups, more reasonable timeouts

### DIFF
--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -61,7 +61,7 @@ func (node *Node) httpRemoteId(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
 	ninfo, err := node.doRemoteId(ctx, pid)
@@ -122,7 +122,7 @@ func (node *Node) httpNetLookup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second) // give the dht more time
 	defer cancel()
 
 	pinfo, err := node.doLookup(ctx, pid)
@@ -148,7 +148,7 @@ func (node *Node) httpPing(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
 	err = node.doPing(ctx, pid)

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -122,10 +122,7 @@ func (node *Node) httpNetLookup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second) // give the dht more time
-	defer cancel()
-
-	pinfo, err := node.doLookup(ctx, pid)
+	pinfo, err := node.doLookup(r.Context(), pid)
 	if err != nil {
 		apiNetError(w, err)
 		return

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -109,6 +109,7 @@ var (
 	NodeOffline      = errors.New("Node is offline")
 	NoDirectory      = errors.New("No directory server")
 	DirectoryError   = errors.New("Directory error")
+	LookupError      = errors.New("Peer lookup failure")
 	UnknownPeer      = errors.New("Unknown peer")
 	IllegalState     = errors.New("Illegal node state")
 )


### PR DESCRIPTION
Improving on the situation with the timeouts and lookups:
- doLookup now does both dir and dht lookups in parallel (instead of first trying the directories and then falling back to the dht) and uses the first available result.
- api timeouts for simple requests are reduced to 10s
- remove netLookup api timeout, as timeouts are explicitly set in the lookup.