### PR TITLE
Use jsonpb for JSON marshalling Statements

### DIFF
--- a/proto/json.go
+++ b/proto/json.go
@@ -1,0 +1,20 @@
+package proto
+
+import (
+	jsonpb "github.com/gogo/protobuf/jsonpb"
+	pb "github.com/gogo/protobuf/proto"
+)
+
+func marshalJSON(m pb.Message) ([]byte, error) {
+	marshaler := jsonpb.Marshaler{}
+	str, err := marshaler.MarshalToString(m)
+	return []byte(str), err
+}
+
+func (m *Statement) MarshalJSON() ([]byte, error) {
+	return marshalJSON(m)
+}
+
+func (m *StatementBody) MarshalJSON() ([]byte, error) {
+	return marshalJSON(m)
+}


### PR DESCRIPTION
Injects the json.Marshaller interface to the protobuf generated code, so that they can be properly marshalled to JSON using jsonpb.
It is only used for statements so far, as they are the only protobuf objects directly translated to json.
Manifests will also use the trick once they are integrated in mcnode/mcdir, in a subsequent PR.

The change is obvious in query output.
Compare:
```

# before
mcclient query "SELECT * FROM images.dpla LIMIT 1"
{
  "id": "4XTTM4K8sqTb7xYviJJcRDJ5W6TpQxMoJ7GtBstTALgh5wzGm:1478267497:1",
  "publisher": "4XTTM4K8sqTb7xYviJJcRDJ5W6TpQxMoJ7GtBstTALgh5wzGm",
  "namespace": "images.dpla",
  "body": {
    "Body": {
      "Simple": {
        "object": "QmeFJSTPKSEiNqebxZvYcduWH8UBmxqNq724gHEQnxV5D1",
        "refs": [
          "dpla_1ff6b36174426026847c8f8ca216ffa9"
        ],
        "deps": [
          "QmYGRQYmWC3BAtTAi88mFb7GVeFsUKGM4nm25SBUB9vfc9"
        ]
      }
    }
  },
  "timestamp": 1478267497,
  "signature": "yDhPpc/RIkW3+sHjl/cB00j3jurqMsDdb/tUyVMUfa6I4EnNiYdSqasxWTiRGtsaT2M/xX++RgRNQQ/97x8IDA=="
}

# after
mcclient query "SELECT * FROM images.dpla LIMIT 1"
{
  "id": "4XTTM4K8sqTb7xYviJJcRDJ5W6TpQxMoJ7GtBstTALgh5wzGm:1478267497:1",
  "publisher": "4XTTM4K8sqTb7xYviJJcRDJ5W6TpQxMoJ7GtBstTALgh5wzGm",
  "namespace": "images.dpla",
  "body": {
    "simple": {
      "object": "QmeFJSTPKSEiNqebxZvYcduWH8UBmxqNq724gHEQnxV5D1",
      "refs": [
        "dpla_1ff6b36174426026847c8f8ca216ffa9"
      ],
      "deps": [
        "QmYGRQYmWC3BAtTAi88mFb7GVeFsUKGM4nm25SBUB9vfc9"
      ]
    }
  },
  "timestamp": "1478267497",
  "signature": "yDhPpc/RIkW3+sHjl/cB00j3jurqMsDdb/tUyVMUfa6I4EnNiYdSqasxWTiRGtsaT2M/xX++RgRNQQ/97x8IDA=="
}
```