### PR TITLE
mcid: make mcid tarball in release package script

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -23,11 +23,15 @@ mkdir -p ${PWD}/dist
 if [ "$OS_NAME" == "linux" ]; then
   strip -o /tmp/mcnode ${GOPATH}/bin/mcnode
   strip -o /tmp/mcdir ${GOPATH}/bin/mcdir
+  strip -o /tmp/mcid ${GOPATH}/bin/mcid
   make_tarball mcnode /tmp
   make_tarball mcdir /tmp
+  make_tarball mcid /tmp
   make_tarball mcnode ${GOPATH}/bin -unstripped
   make_tarball mcdir ${GOPATH}/bin -unstripped
+  make_tarball mcid ${GOPATH}/bin -unstripped
 else
   make_tarball mcnode ${GOPATH}/bin
   make_tarball mcdir ${GOPATH}/bin
+  make_tarball mcid ${GOPATH}/bin
 fi


### PR DESCRIPTION
This just adds mcid to the `package.sh` script that make our release tarballs.  Travis is setup to upload `dist/*.tgz` as part of the release, so it should get uploaded automatically.