### PR TITLE
More IPFS interop

### DIFF
--- a/mc/version.go
+++ b/mc/version.go
@@ -1,0 +1,13 @@
+package mc
+
+import (
+	"fmt"
+	p2p_id "github.com/libp2p/go-libp2p/p2p/protocol/identify"
+)
+
+const ConcatVersion = "1.5-DEV"
+const Libp2pVersion = "go-libp2p/4.3.1"
+
+func SetLibp2pClient(prog string) {
+	p2p_id.ClientVersion = fmt.Sprintf("%s/%s (%s)", prog, ConcatVersion, Libp2pVersion)
+}

--- a/mcdir/main.go
+++ b/mcdir/main.go
@@ -267,6 +267,8 @@ func (dir *Directory) listNamespaces() []string {
 }
 
 func main() {
+	mc.SetLibp2pClient("mcdir")
+
 	port := flag.Int("l", 9000, "Listen port")
 	hdir := flag.String("d", "~/.mediachain/mcdir", "Directory home")
 	flag.Parse()

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -133,9 +133,33 @@ func (node *Node) httpNetLookup(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// GET /net/ping/{peerId}
+// Ping a peer using the ipfs ping protocol
+func (node *Node) httpNetPing(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	peerId := vars["peerId"]
+	pid, err := p2p_peer.IDB58Decode(peerId)
+	if err != nil {
+		apiError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	dt, err := node.netPing(ctx, pid)
+	if err != nil {
+		apiNetError(w, err)
+		return
+	}
+
+	fmt.Fprintln(w, dt)
+}
+
 // GET /ping/{peerId}
 // Lookup a peer in the directory and ping it with the /mediachain/node/ping protocol.
 // The node must be online and a directory must have been configured.
+// DEPRECATED in favor of /net/ping
 func (node *Node) httpPing(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	peerId := vars["peerId"]

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -133,6 +133,32 @@ func (node *Node) httpNetLookup(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// GET /net/identify/{peerId}
+// Identify a peer using information collected by the libp2p identify service
+func (node *Node) httpNetIdentify(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	peerId := vars["peerId"]
+	pid, err := p2p_peer.IDB58Decode(peerId)
+	if err != nil {
+		apiError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	nid, err := node.netIdentify(ctx, pid)
+	if err != nil {
+		apiNetError(w, err)
+		return
+	}
+
+	err = json.NewEncoder(w).Encode(nid)
+	if err != nil {
+		log.Printf("Error writing response body: %s", err.Error())
+	}
+}
+
 // GET /net/ping/{peerId}
 // Ping a peer using the ipfs ping protocol
 func (node *Node) httpNetPing(w http.ResponseWriter, r *http.Request) {

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -12,6 +12,8 @@ import (
 )
 
 func main() {
+	mc.SetLibp2pClient("mcnode")
+
 	pport := flag.Int("l", 9001, "Peer listen port")
 	cport := flag.Int("c", 9002, "Peer control interface port [http]")
 	bindaddr := flag.String("b", "127.0.0.1", "Peer control bind address [http]")

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -106,6 +106,7 @@ func main() {
 	router.HandleFunc("/net/addr/{peerId}", node.httpNetPeerAddr)
 	router.HandleFunc("/net/conns", node.httpNetConns)
 	router.HandleFunc("/net/lookup/{peerId}", node.httpNetLookup)
+	router.HandleFunc("/net/identify/{peerId}", node.httpNetIdentify)
 	router.HandleFunc("/net/ping/{peerId}", node.httpNetPing)
 	router.HandleFunc("/shutdown", node.httpShutdown)
 

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -106,6 +106,7 @@ func main() {
 	router.HandleFunc("/net/addr/{peerId}", node.httpNetPeerAddr)
 	router.HandleFunc("/net/conns", node.httpNetConns)
 	router.HandleFunc("/net/lookup/{peerId}", node.httpNetLookup)
+	router.HandleFunc("/net/ping/{peerId}", node.httpNetPing)
 	router.HandleFunc("/shutdown", node.httpShutdown)
 
 	log.Printf("Serving client interface at %s", haddr)

--- a/mcnode/net.go
+++ b/mcnode/net.go
@@ -327,6 +327,27 @@ func (node *Node) netConns() []p2p_pstore.PeerInfo {
 	return peers
 }
 
+func (node *Node) netPing(ctx context.Context, pid p2p_peer.ID) (dt time.Duration, err error) {
+	err = node.doConnectPeer(ctx, pid)
+	if err != nil {
+		return
+	}
+
+	ch, err := node.ping.Ping(ctx, pid)
+	if err != nil {
+		return
+	}
+
+	select {
+	case <-ctx.Done():
+		err = ctx.Err()
+		return
+
+	case dt = <-ch:
+		return
+	}
+}
+
 // Connectivity
 func (node *Node) doConnect(ctx context.Context, pid p2p_peer.ID, proto p2p_proto.ID) (p2p_net.Stream, error) {
 	err := node.doConnectPeer(ctx, pid)

--- a/mcnode/net.go
+++ b/mcnode/net.go
@@ -7,6 +7,7 @@ import (
 	p2p_peer "github.com/libp2p/go-libp2p-peer"
 	p2p_pstore "github.com/libp2p/go-libp2p-peerstore"
 	p2p_proto "github.com/libp2p/go-libp2p-protocol"
+	p2p_ping "github.com/libp2p/go-libp2p/p2p/protocol/ping"
 	mc "github.com/mediachain/concat/mc"
 	mcq "github.com/mediachain/concat/mc/query"
 	pb "github.com/mediachain/concat/proto"
@@ -37,6 +38,7 @@ func (node *Node) goOffline() error {
 			log.Printf("Error closing host: %s", err.Error())
 		}
 		node.host = nil
+		node.ping = nil
 
 		node.status = StatusOffline
 		node.natCfg.Clear()
@@ -88,6 +90,8 @@ func (node *Node) _goOnline() error {
 	host.SetStreamHandler("/mediachain/node/data", node.dataHandler)
 	host.SetStreamHandler("/mediachain/node/push", node.pushHandler)
 
+	ping := p2p_ping.NewPingService(host)
+
 	dht := NewDHT(ctx, host)
 
 	err = dht.Bootstrap()
@@ -99,6 +103,7 @@ func (node *Node) _goOnline() error {
 	node.host = host
 	node.netCtx = ctx
 	node.netCancel = cancel
+	node.ping = ping
 	node.dht = dht
 
 	return nil

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -10,6 +10,7 @@ import (
 	p2p_host "github.com/libp2p/go-libp2p-host"
 	p2p_peer "github.com/libp2p/go-libp2p-peer"
 	p2p_pstore "github.com/libp2p/go-libp2p-peerstore"
+	p2p_ping "github.com/libp2p/go-libp2p/p2p/protocol/ping"
 	mc "github.com/mediachain/concat/mc"
 	mcq "github.com/mediachain/concat/mc/query"
 	pb "github.com/mediachain/concat/proto"
@@ -33,6 +34,7 @@ type Node struct {
 	host      p2p_host.Host
 	netCtx    context.Context
 	netCancel context.CancelFunc
+	ping      *p2p_ping.PingService
 	dht       DHT
 	dir       []p2p_pstore.PeerInfo
 	natCfg    mc.NATConfig

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -91,6 +91,15 @@ type NodeInfo struct {
 	Info      string `json:"info"`
 }
 
+type NetIdentify struct {
+	ID              string
+	PublicKey       []byte
+	Addresses       []string
+	AgentVersion    string
+	ProtocolVersion string
+	Protocols       []string
+}
+
 var (
 	UnknownStatement = errors.New("Unknown statement")
 	UnknownObject    = errors.New("Unknown Object")

--- a/mcnode/proto.go
+++ b/mcnode/proto.go
@@ -16,6 +16,7 @@ import (
 )
 
 func (node *Node) pingHandler(s p2p_net.Stream) {
+	// DEPRECATED in favor of libp2p.PingService
 	defer s.Close()
 
 	pid := mc.LogStreamHandler(s)
@@ -359,6 +360,7 @@ func (node *Node) doRemoteId(ctx context.Context, pid p2p_peer.ID) (empty NodeIn
 }
 
 func (node *Node) doPing(ctx context.Context, pid p2p_peer.ID) error {
+	// DEPRECATED in favor of libp2p.PingService; see netPing
 	s, err := node.doConnect(ctx, pid, "/mediachain/node/ping")
 	if err != nil {
 		return err

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmbzCT1CwxVZ2ednptC9RavuJe7Bv8DDi2Ne89qUrA37XM",
+      "hash": "QmQHmMFyhfp2ZXnbYWqAWhEideDCNDM6hzJwqCU29Y5zV2",
       "name": "go-libp2p",
-      "version": "4.3.0"
+      "version": "4.3.1"
     },
     {
-      "hash": "QmUXmpsmyoQEP5ahxdEehsPeNJ59PXTmkjxLbZEyYrJci9",
+      "hash": "QmYTccce26rGtEbE7SpnSeRcJkT4uqa7aPyzRXufisiTEd",
       "name": "go-libp2p-kad-dht",
-      "version": "2.4.9"
+      "version": "2.4.10"
     },
     {
       "author": "whyrusleeping",


### PR DESCRIPTION
Further improves on our IPFS interoperability [#78]:
- Sets the ClientVersion to identify our nodes through the `/ipfs/identify` protocol; new in libp2p-4.3.1
- Integrates the libp2p PingService, so that nodes can ping/pong using the ipfs protocol and deprecates the `/mediachain/node/ping` protocol
- New net api hooks
  - `/net/ping/{peerId}` to ping using the ping service
  - `/net/identify/{peerId}` for dumping the information collected for a peer by the libp2p IdentifyService

Examples:
```
$ mcclient id QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp
Peer ID: QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp
Publisher ID: 4XTTMGkYEx5trQX5VV32S82gguRMtVFQL5UDnZNHzyNEHKBeZ
Info: Mediachain Labs test node

# IPFS interop
$ ipfs swarm connect /ip4/54.242.130.109/tcp/9001/ipfs/QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp
connect QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp success
$ ipfs id QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp
{
	"ID": "QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp",
	"PublicKey": "CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAdr/hsR6nbvzRWRyGUsV1/W6M+ZQRKW8UQ+2DnYnGIzzz4bXOtbAnRWMr+OrfanL59MsagZT5RHo+PWJ75cGcgigqSY8MgChi6wNfE6ibplz5t0DONPCJP/Yy5fxXdqUIN/lQouou6YnX1VZg0ABRI1qZzGmbTZDoIyURBUgRicWyjB4ktd68uNYHJTfNbFHIf53ieQ/JSQWAF6mk9h1CsKJc6AmZ679szinYcowCT3pywFCBLfUeP2eQ/WMUXjtkNtm3GyiiPizCcImfmxskdNiCxq5YwgbklzgQwD6rY5Aj7MTdDzcG/6bqW3lZ20F8FCr/dWSjKE4H9YV2A8EFAgMBAAE=",
	"Addresses": [
		"/ip4/127.0.0.1/tcp/9001",
		"/ip4/54.242.130.109/tcp/9001",
		"/ip4/10.10.1.191/tcp/9001"
	],
	"AgentVersion": "mcnode/1.5-DEV (go-libp2p/4.3.1)",
	"ProtocolVersion": "ipfs/0.1.0"
}
$ ipfs ping QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp
PING QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp.
Pong received: time=2231.75 ms
Pong received: time=677.09 ms
Pong received: time=453.78 ms
Pong received: time=554.48 ms
Pong received: time=183.00 ms
Pong received: time=176.55 ms
Pong received: time=179.70 ms
Pong received: time=191.70 ms
Pong received: time=180.16 ms
Pong received: time=1301.63 ms
Average latency: 612.98ms

# New net apis
$ curl http://localhost:9002/net/ping/QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp
507.536604ms
$ curl http://localhost:9002/net/identify/QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp
{"ID":"QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp","PublicKey":"CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAdr/hsR6nbvzRWRyGUsV1/W6M+ZQRKW8UQ+2DnYnGIzzz4bXOtbAnRWMr+OrfanL59MsagZT5RHo+PWJ75cGcgigqSY8MgChi6wNfE6ibplz5t0DONPCJP/Yy5fxXdqUIN/lQouou6YnX1VZg0ABRI1qZzGmbTZDoIyURBUgRicWyjB4ktd68uNYHJTfNbFHIf53ieQ/JSQWAF6mk9h1CsKJc6AmZ679szinYcowCT3pywFCBLfUeP2eQ/WMUXjtkNtm3GyiiPizCcImfmxskdNiCxq5YwgbklzgQwD6rY5Aj7MTdDzcG/6bqW3lZ20F8FCr/dWSjKE4H9YV2A8EFAgMBAAE=","Addresses":["/ip4/10.10.1.191/tcp/9001","/ip4/127.0.0.1/tcp/9001","/ip4/54.242.130.109/tcp/9001"],"AgentVersion":"mcnode/1.5-DEV (go-libp2p/4.3.1)","ProtocolVersion":"ipfs/0.1.0","Protocols":["/mediachain/node/id","/mediachain/node/ping","/mediachain/node/query","/mediachain/node/data","/mediachain/node/push","/ipfs/ping/1.0.0","/ipfs/id/1.0.0","/ipfs/relay/line/0.1.0"]}
```

cc @whyrusleeping 