### PR TITLE
Support keybase for entity keys

### DIFF
--- a/mc/entity.go
+++ b/mc/entity.go
@@ -20,6 +20,11 @@ var (
 	EntityKeyNotFound = errors.New("Entity key not found")
 )
 
+type EntityId struct {
+	KeyId string `json:"keyId"` // public key multihash
+	Key   []byte `json:"key"`   // marshalled public key
+}
+
 func LookupEntityKey(entity string, keyId string) (p2p_crypto.PubKey, error) {
 	ix := strings.Index(entity, ":")
 	if ix < 0 {

--- a/mc/entity.go
+++ b/mc/entity.go
@@ -170,7 +170,11 @@ func unmarshalEntityKey(key string, khash multihash.Multihash) (p2p_crypto.PubKe
 }
 
 func unmarshalEntityKeyBytes(key []byte, khash multihash.Multihash) (p2p_crypto.PubKey, error) {
-	hash := Hash(key)
+	hash, err := multihash.Sum(key, int(khash[0]), -1)
+	if err != nil {
+		return nil, err
+	}
+
 	if !bytes.Equal(hash, khash) {
 		return nil, EntityKeyNotFound
 	}

--- a/mcid/main.go
+++ b/mcid/main.go
@@ -53,13 +53,8 @@ func main() {
 }
 
 type Identity struct {
-	Public  PublicId  `json:"public"`
-	Private PrivateId `json:"private"`
-}
-
-type PublicId struct {
-	KeyId string `json:"keyId"` // public key multihash
-	Key   []byte `json:"key"`   // marshalled public key
+	Public  mc.EntityId `json:"public"`
+	Private PrivateId   `json:"private"`
 }
 
 type PrivateId struct {


### PR DESCRIPTION
Adds support for keybase users, through the `keybase:user` entity scheme [#14]
The entity key is distributed through kbfs with a public file named `mediachain.json`, which contains the output of `mcid id`.