### PR TITLE
version command 

### DIFF
--- a/mc/version.go
+++ b/mc/version.go
@@ -5,7 +5,7 @@ import (
 	p2p_id "github.com/libp2p/go-libp2p/p2p/protocol/identify"
 )
 
-const ConcatVersion = "1.5"
+const ConcatVersion = "1.6-DEV"
 const Libp2pVersion = "go-libp2p/4.3.1"
 
 func SetLibp2pClient(prog string) {

--- a/mcdir/main.go
+++ b/mcdir/main.go
@@ -271,12 +271,18 @@ func main() {
 
 	port := flag.Int("l", 9000, "Listen port")
 	hdir := flag.String("d", "~/.mediachain/mcdir", "Directory home")
+	ver := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
 
 	if len(flag.Args()) != 0 {
 		fmt.Fprintf(os.Stderr, "Usage: %s [options ...]\nOptions:\n", os.Args[0])
 		flag.PrintDefaults()
 		os.Exit(1)
+	}
+
+	if *ver {
+		fmt.Println(mc.ConcatVersion)
+		os.Exit(0)
 	}
 
 	home, err := homedir.Expand(*hdir)

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -18,12 +18,18 @@ func main() {
 	cport := flag.Int("c", 9002, "Peer control interface port [http]")
 	bindaddr := flag.String("b", "127.0.0.1", "Peer control bind address [http]")
 	hdir := flag.String("d", "~/.mediachain/mcnode", "Node home")
+	ver := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
 
 	if len(flag.Args()) != 0 {
 		fmt.Fprintf(os.Stderr, "Usage: %s [options ...]\nOptions:\n", os.Args[0])
 		flag.PrintDefaults()
 		os.Exit(1)
+	}
+
+	if *ver {
+		fmt.Println(mc.ConcatVersion)
+		os.Exit(0)
 	}
 
 	addr, err := mc.ParseAddress(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", *pport))


### PR DESCRIPTION
Closes #120 
mcnode and mcdir: print version and exit with `-version`.

Note that we can't haz `--version`, as the golang `flag` package barfs if I use a dashed flag name...

Example:
```
$ mcnode -version
1.6-DEV
$ mcdir -version
1.6-DEV
```