### PR TITLE
Disable rocksdb concurrent writes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
 
 # copy previously cached deps into GOPATH
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get update -qq && sudo apt-get install gcc-6 g++-6 libsnappy-dev zlib1g-dev libbz2-dev -qq; fi
   - if [[ -d "$HOME/gocache/src" && -d "$HOME/gocache/pkg" ]]; then rsync -a "$HOME/gocache/" "$GOPATH/"; fi
 
 install:
@@ -43,8 +42,8 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-4.8
-      - g++-4.8
+      - gcc-6
+      - g++-6
 
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,11 @@ matrix:
 
 # copy previously cached deps into GOPATH
 before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get update -qq && sudo apt-get install gcc-6 g++-6 libsnappy-dev zlib1g-dev libbz2-dev -qq; fi
   - if [[ -d "$HOME/gocache/src" && -d "$HOME/gocache/pkg" ]]; then rsync -a "$HOME/gocache/" "$GOPATH/"; fi
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX="g++-4.8" CC="gcc-4.8" CXXFLAGS="-stdlib=libc++" LDFLAGS="-stdlib=libc++ -std=c++11 -lrt -Wl,--no-as-needed"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX="g++-6" CC="gcc-6" CXXFLAGS="-stdlib=libc++" LDFLAGS="-stdlib=libc++ -std=c++11 -lrt -Wl,--no-as-needed"; fi
   - ./setup.sh
   - ./install.sh
   - ./package.sh

--- a/mcnode/ds.go
+++ b/mcnode/ds.go
@@ -49,6 +49,7 @@ func (ds *RocksDS) Open(home string) error {
 		}
 	}
 	opts.OptimizeForPointLookup(uint64(bcmb))
+	opts.SetAllowConcurrentMemtableWrites(false)
 
 	db, err := rocksdb.OpenDb(opts, dbpath)
 	if err != nil {


### PR DESCRIPTION
See https://github.com/mediachain/gorocksdb/pull/1

Basically, the latest rocksdb release (used by the embedded build in gorocksdb as of a few days ago), throws if you try to use `OptimizeForPointLookup` without setting the `allow_concurrent_memtable_write` option to `false`.  I added a setter for that option to our fork (and made a PR against the upstream repo: https://github.com/tecbot/gorocksdb/pull/75), and call it from `RocksDS.Open` to avoid the crash.

I haven't measured how this might impact ingestion performance, but it seems that the unsupported concurrent writes could lead to unpredictable crashes, so I guess it's a good thing to disable them.  