### PR TITLE
Peer discovery through DHT rendezvous

### DIFF
--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -182,6 +182,23 @@ func (node *Node) httpNetPing(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, dt)
 }
 
+// GET /net/find
+// Find peers through DHT rendezvous
+func (node *Node) httpNetFindPeers(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	ch, err := node.netFindPeers(ctx)
+	if err != nil {
+		apiNetError(w, err)
+		return
+	}
+
+	for pinfo := range ch {
+		fmt.Fprintln(w, pinfo.ID.Pretty())
+	}
+}
+
 // GET /ping/{peerId}
 // Lookup a peer in the directory and ping it with the /mediachain/node/ping protocol.
 // The node must be online and a directory must have been configured.

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -118,6 +118,7 @@ func main() {
 	router.HandleFunc("/net/lookup/{peerId}", node.httpNetLookup)
 	router.HandleFunc("/net/identify/{peerId}", node.httpNetIdentify)
 	router.HandleFunc("/net/ping/{peerId}", node.httpNetPing)
+	router.HandleFunc("/net/find", node.httpNetFindPeers)
 	router.HandleFunc("/shutdown", node.httpShutdown)
 
 	log.Printf("Serving client interface at %s", haddr)

--- a/mcnode/net.go
+++ b/mcnode/net.go
@@ -436,6 +436,10 @@ func (node *Node) netFindPeers(ctx context.Context) (<-chan p2p_pstore.PeerInfo,
 	go func() {
 		defer close(och)
 		for pinfo := range ich {
+			if pinfo.ID == node.ID {
+				continue
+			}
+
 			node.host.Peerstore().AddAddrs(pinfo.ID, pinfo.Addrs, p2p_pstore.ProviderAddrTTL)
 
 			select {

--- a/mcnode/net.go
+++ b/mcnode/net.go
@@ -426,6 +426,14 @@ identify:
 	return
 }
 
+func (node *Node) netFindPeers(ctx context.Context) (<-chan p2p_pstore.PeerInfo, error) {
+	if node.status == StatusOffline {
+		return nil, NodeOffline
+	}
+
+	return node.dht.FindProviders(ctx, "/mediachain/node"), nil
+}
+
 // Connectivity
 func (node *Node) doConnect(ctx context.Context, pid p2p_peer.ID, proto p2p_proto.ID) (p2p_net.Stream, error) {
 	err := node.doConnectPeer(ctx, pid)

--- a/mcnode/net.go
+++ b/mcnode/net.go
@@ -128,8 +128,8 @@ func (node *Node) goPublic() error {
 			return err
 		}
 
-		// wait a bit for NAT port mapping to take effect and DHT bootstrap
-		time.Sleep(2 * time.Second)
+		// wait a bit for the DHT to bootstrap and NAT port mapping to take effect
+		time.Sleep(5 * time.Second)
 		fallthrough
 
 	case StatusOnline:

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -78,6 +78,8 @@ type Datastore interface {
 type DHT interface {
 	Bootstrap() error
 	Lookup(ctx context.Context, pid p2p_peer.ID) (p2p_pstore.PeerInfo, error)
+	Provide(ctx context.Context, key string) error
+	FindProviders(ctx context.Context, key string) <-chan p2p_pstore.PeerInfo
 	Close() error
 }
 


### PR DESCRIPTION
The gist: ue use DHT provider records as a rendezvous mechanism:
- public peers provide the magic "/mediachain/node" key in the DHT
- the `/net/find` api allows us to discover peers though a provider query

Example:
```
$ curl http://127.0.0.1:9002/net/find
QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp

$ mcclient id QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp
Peer ID: QmSbgwkKxtrBFDoGGwoKqH7soYiL64xpMK5oEYdiRnQGJp
Publisher ID: 4XTTMGkYEx5trQX5VV32S82gguRMtVFQL5UDnZNHzyNEHKBeZ
Info: Mediachain Labs test node
```