### PR TITLE
StatementDB vacuum support

### DIFF
--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -682,6 +682,28 @@ func (node *Node) httpDelete(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, count)
 }
 
+// POST /vacuum/incremental
+// Perform an incremental vacuum in the statement db
+func (node *Node) httpVacuumIncremental(w http.ResponseWriter, r *http.Request) {
+	err := node.db.Vacuum(false)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, err)
+	}
+
+	fmt.Fprintln(w, "OK")
+}
+
+// POST /vacuum/incremental
+// Perform a full vacuum in the statement db
+func (node *Node) httpVacuumFull(w http.ResponseWriter, r *http.Request) {
+	err := node.db.Vacuum(true)
+	if err != nil {
+		apiError(w, http.StatusInternalServerError, err)
+	}
+
+	fmt.Fprintln(w, "OK")
+}
+
 // datastore interface
 type DataObject struct {
 	Data []byte `json:"data"`

--- a/mcnode/api.go
+++ b/mcnode/api.go
@@ -688,6 +688,7 @@ func (node *Node) httpVacuumIncremental(w http.ResponseWriter, r *http.Request) 
 	err := node.db.Vacuum(false)
 	if err != nil {
 		apiError(w, http.StatusInternalServerError, err)
+		return
 	}
 
 	fmt.Fprintln(w, "OK")
@@ -699,6 +700,7 @@ func (node *Node) httpVacuumFull(w http.ResponseWriter, r *http.Request) {
 	err := node.db.Vacuum(true)
 	if err != nil {
 		apiError(w, http.StatusInternalServerError, err)
+		return
 	}
 
 	fmt.Fprintln(w, "OK")

--- a/mcnode/db.go
+++ b/mcnode/db.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	ggproto "github.com/gogo/protobuf/proto"
 	sqlite3 "github.com/mattn/go-sqlite3"
 	mcq "github.com/mediachain/concat/mc/query"
@@ -517,6 +518,17 @@ func (sdb *SQLiteDB) vacuumFull() error {
 }
 
 func (sdb *SQLiteDB) vacuumIncremental() error {
-	_, err := sdb.db.Exec("PRAGMA incremental_vacuum")
+	var autovac int
+	row := sdb.db.QueryRow("PRAGMA auto_vacuum")
+	err := row.Scan(&autovac)
+	if err != nil {
+		return err
+	}
+
+	if autovac != 2 {
+		return fmt.Errorf("Incremental vacuum not enabled in the database; run a full vacuum first")
+	}
+
+	_, err = sdb.db.Exec("PRAGMA incremental_vacuum")
 	return err
 }

--- a/mcnode/db.go
+++ b/mcnode/db.go
@@ -393,12 +393,12 @@ func (sdb *SQLiteDB) Open(home string) error {
 	}
 
 	if mktables {
-		err = sdb.createTables()
+		err = sdb.tuneDB()
 		if err != nil {
 			return err
 		}
 
-		err = sdb.tuneDB()
+		err = sdb.createTables()
 		if err != nil {
 			return err
 		}
@@ -419,6 +419,11 @@ func (sdb *SQLiteDB) openDB(dbpath string) error {
 
 func (sdb *SQLiteDB) tuneDB() error {
 	_, err := sdb.db.Exec("PRAGMA journal_mode=WAL")
+	if err != nil {
+		return err
+	}
+
+	_, err = sdb.db.Exec("PRAGMA auto_vacuum=INCREMENTAL")
 	return err
 }
 

--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -89,6 +89,8 @@ func main() {
 	router.HandleFunc("/merge/{peerId}", node.httpMerge)
 	router.HandleFunc("/push/{peerId}", node.httpPush)
 	router.HandleFunc("/delete", node.httpDelete)
+	router.HandleFunc("/vacuum/incremental", node.httpVacuumIncremental)
+	router.HandleFunc("/vacuum/full", node.httpVacuumFull)
 	router.HandleFunc("/data/put", node.httpPutData)
 	router.HandleFunc("/data/get", node.httpGetDataBatch)
 	router.HandleFunc("/data/get/{objectId}", node.httpGetData)

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -58,6 +58,7 @@ type StatementDB interface {
 	Merge(*pb.Statement) (bool, error)
 	MergeBatch([]*pb.Statement) (int, error)
 	Delete(*mcq.Query) (int, error)
+	Vacuum(full bool) error
 	Close() error
 }
 


### PR DESCRIPTION
Adds support for vacuuming the StatementDB: 
- Incremental vacuum can recover space following deletes. 
- Full vacuum recovers space and compacts the database. However, it needs lots of free space (as much as the live data set).

Implementation:
- New node databases are now created with `auto_vacuum=incremental`
- `/vacuum/incremental` performs an incremental vacuum, if it is enabled in the db. 
- `/vacuum/full` performs a full compacting vacuum, and it also sets the auto_vacuum mode to incremental for migrating existing node databases.
