### PR TITLE
Implement statement import for archive support

### DIFF
--- a/mcnode/main.go
+++ b/mcnode/main.go
@@ -83,6 +83,7 @@ func main() {
 	router.HandleFunc("/ping/{peerId}", node.httpPing)
 	router.HandleFunc("/publish/{namespace}", node.httpPublish)
 	router.HandleFunc("/publish/{namespace}/{combine}", node.httpPublishCompound)
+	router.HandleFunc("/import", node.httpImport)
 	router.HandleFunc("/stmt/{statementId}", node.httpStatement)
 	router.HandleFunc("/query", node.httpQuery)
 	router.HandleFunc("/query/{peerId}", node.httpRemoteQuery)

--- a/mcnode/node.go
+++ b/mcnode/node.go
@@ -196,6 +196,25 @@ func (node *Node) doPublishBatch(ns string, lst []interface{}) ([]string, error)
 	return sids, err
 }
 
+func (node *Node) doImport(stmts []*pb.Statement, pkcache map[string]p2p_crypto.PubKey) (int, error) {
+	for _, stmt := range stmts {
+		if !node.checkStatement(stmt) {
+			return 0, BadStatement
+		}
+
+		verify, err := node.verifyStatementCacheKeys(stmt, pkcache)
+		if err != nil {
+			return 0, err
+		}
+
+		if !verify {
+			return 0, BadStatement
+		}
+	}
+
+	return node.db.MergeBatch(stmts)
+}
+
 func (node *Node) makeStatement(ns string, body interface{}) (*pb.Statement, error) {
 	stmt := new(pb.Statement)
 	pid := node.publisher.ID58

--- a/proto/json.go
+++ b/proto/json.go
@@ -23,6 +23,14 @@ func (m *StatementBody) MarshalJSON() ([]byte, error) {
 	return marshalJSON(m)
 }
 
+func (m *Statement) UnmarshalJSON(data []byte) error {
+	return unmarshalJSON(data, m)
+}
+
+func (m *StatementBody) UnmarshalJSON(data []byte) error {
+	return unmarshalJSON(data, m)
+}
+
 func (m *Manifest) MarshalJSON() ([]byte, error) {
 	return marshalJSON(m)
 }


### PR DESCRIPTION
Implements the `/import` API endpoint, which verifies and merges a stream of existing statements.
Closes #134 

Example:
```
$ mcclient id QmeiY2eHMwK92Zt6X4kUUC3MsjMmVb2VnGZ17DhnhRPCEQ
Peer ID: QmeiY2eHMwK92Zt6X4kUUC3MsjMmVb2VnGZ17DhnhRPCEQ
Publisher ID: 4XTTM4K8sqTb7xYviJJcRDJ5W6TpQxMoJ7GtBstTALgh5wzGm
Info: Metadata for CC images from DPLA, 500px, and pexels; operated by Mediachain Labs.
$ mcclient query -r QmeiY2eHMwK92Zt6X4kUUC3MsjMmVb2VnGZ17DhnhRPCEQ "SELECT * FROM images.500px LIMIT 1000" > /tmp/500px.json
$ curl --data-binary @/tmp/500px.json http://127.0.0.1:9002/import
1000
$ mcclient query "SELECT COUNT(*) FROM images.500px"
1000
$ mcclient query -r QmeiY2eHMwK92Zt6X4kUUC3MsjMmVb2VnGZ17DhnhRPCEQ "SELECT * FROM images.500px LIMIT 5000" > /tmp/more-500px.json
$ curl --data-binary @/tmp/more-500px.json http://127.0.0.1:9002/import
4000
$ mcclient query "SELECT COUNT(*) FROM images.500px"
5000
```