### PR TITLE
Release 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 14/3/2017: concat-v1.7
+- Added `/import` HTTP endpoint for merging a stream of existing signed statements (used for loading archives) [[PR #135]](https://github.com/mediachain/concat/pull/135)
+
 ## 13/2/2017: concat-v1.6
 - Directory extensions for manifest lookup [[PR #125]](https://github.com/mediachain/concat/pull/125)
 - Peer discovery through DHT rendezvous [[PR #128]](https://github.com/mediachain/concat/pull/128)

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ A REST API is provided for controlling the node. This is an administrative inter
 * `GET /ping/{peerId}` -- ping! [DEPRECATED]
 * `POST /publish/{namespace}` -- publish a batch of statements to the specified namespace 
 * `POST /publish/{namespace}/{combine}` -- publish a batch of statements with CompoundStatement grouping 
+* `POST /import` -- ingest a stream of json-encoded signed statements (e.g. from an archive)
 * `GET /stmt/{statementId}` -- retrieve statement by statementId
 * `POST /query` -- issue MCQL SELECT query on the local node
 * `POST /query/{peerId}` -- issue MCQL SELECT query on a remote peer

--- a/mc/version.go
+++ b/mc/version.go
@@ -5,7 +5,7 @@ import (
 	p2p_id "github.com/libp2p/go-libp2p/p2p/protocol/identify"
 )
 
-const ConcatVersion = "1.6"
+const ConcatVersion = "1.7"
 const Libp2pVersion = "go-libp2p/4.3.1"
 
 func SetLibp2pClient(prog string) {


### PR DESCRIPTION
Updates CHANGELOG, README to include the `/import` endpoint, and bumps the version to 1.7 in `mc/version.go`